### PR TITLE
Remove activeFetchersRef pattern and fix onBlur on drawer close

### DIFF
--- a/app/components/translation-key/TranslationKeyContent.tsx
+++ b/app/components/translation-key/TranslationKeyContent.tsx
@@ -74,8 +74,6 @@ type TranslationKeyContentProps = {
   actionUrl?: string;
   /** Whether to show in compact layout (e.g. inside a drawer). */
   compact?: boolean;
-  /** Callback when the number of active fetchers changes. */
-  onFetcherStateChange?: (activeFetchers: number) => void;
 };
 
 export function TranslationKeyContent({
@@ -87,7 +85,6 @@ export function TranslationKeyContent({
   hasAiProvider,
   actionUrl,
   compact = false,
-  onFetcherStateChange,
 }: TranslationKeyContentProps) {
   const { t } = useTranslation();
 
@@ -113,7 +110,6 @@ export function TranslationKeyContent({
     organization,
     project,
     actionUrl,
-    onFetcherStateChange,
   });
 
   const editKeyError =

--- a/app/components/translation-key/TranslationKeyDrawer.tsx
+++ b/app/components/translation-key/TranslationKeyDrawer.tsx
@@ -5,10 +5,8 @@
  * and renders <TranslationKeyContent /> for inline editing from the
  * translations list — without navigating to a separate page.
  *
- * The drawer waits for all pending save operations before closing,
- * ensuring data consistency.
  */
-import { useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
 import {
   DrawerRoot,
   DrawerBackdrop,
@@ -39,7 +37,7 @@ type TranslationKeyDrawerProps = {
   keyId: number;
   organizationSlug: string;
   projectSlug: string;
-  /** Called when the drawer is fully closed (after all pending saves). */
+  /** Called when the drawer is closed. */
   onClosed: () => void;
 };
 
@@ -54,30 +52,12 @@ export function TranslationKeyDrawer({
   // Fetcher for loading key data
   const dataFetcher = useFetcher<KeyLoaderData>();
 
-  // Track if user wants to close (wait for pending operations)
-  const [isClosing, setIsClosing] = useState(false);
-
-  // Track active fetchers from TranslationKeyContent
-  const activeFetchersRef = useRef(0);
-
-  // Internal open state to prevent premature closing
-  const [internalOpen, setInternalOpen] = useState(true);
-
   const keyUrl = getKeyUrl(organizationSlug, projectSlug, keyId);
 
   // Load key data when component mounts or keyId changes
   useEffect(() => {
     dataFetcher.load(keyUrl);
   }, [keyUrl]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Actually close the drawer when user wants to close AND no pending operations
-  useEffect(() => {
-    if (isClosing && activeFetchersRef.current === 0) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setInternalOpen(false);
-      onClosed();
-    }
-  }, [isClosing, onClosed]);
 
   const isLoading = dataFetcher.state === "loading";
   const data = dataFetcher.data;
@@ -91,24 +71,20 @@ export function TranslationKeyDrawer({
     onClosed();
   };
 
-  const handleCloseRequest = () => {
-    setIsClosing(true);
-  };
-
-  const handleFetcherStateChange = (activeFetchers: number) => {
-    activeFetchersRef.current = activeFetchers;
-  };
-
   if (dataFetcher.state === "idle" && !data) {
     return null;
   }
 
   return (
     <DrawerRoot
-      open={internalOpen}
+      open
       onOpenChange={(e) => {
         if (!e.open) {
-          handleCloseRequest();
+          if (document.activeElement instanceof HTMLElement) {
+            // trigger blur on active element to save any unsaved changes in TranslationKeyContent before closing
+            document.activeElement.blur();
+          }
+          onClosed();
         }
       }}
       placement="end"
@@ -161,7 +137,6 @@ export function TranslationKeyDrawer({
                 project={data.project}
                 hasAiProvider={data.hasAiProvider}
                 actionUrl={keyUrl}
-                onFetcherStateChange={handleFetcherStateChange}
                 compact
               />
             ) : (

--- a/app/components/translation-key/useTranslationKeyEditor.tsx
+++ b/app/components/translation-key/useTranslationKeyEditor.tsx
@@ -20,8 +20,6 @@ type UseTranslationKeyEditorParams = {
   project: Project;
   /** URL to POST actions to (save, editKey). Defaults to current route. */
   actionUrl?: string;
-  /** Callback when the number of active fetchers changes. */
-  onFetcherStateChange?: (activeFetchers: number) => void;
 };
 
 type ReturnType = {
@@ -58,7 +56,6 @@ export function useTranslationKeyEditor({
   organization,
   project,
   actionUrl,
-  onFetcherStateChange,
 }: UseTranslationKeyEditorParams): ReturnType {
   const { t } = useTranslation();
 
@@ -133,20 +130,6 @@ export function useTranslationKeyEditor({
   // AI translation state
   const [aiDialogLocale, setAiDialogLocale] = useState<string | null>(null);
   const aiFetcher = useFetcher<TranslateAction>();
-
-  // Track active fetchers
-  useEffect(() => {
-    const count =
-      (saveFetcher.state !== "idle" ? 1 : 0) +
-      (editKeyFetcher.state !== "idle" ? 1 : 0) +
-      (aiFetcher.state !== "idle" ? 1 : 0);
-    onFetcherStateChange?.(count);
-  }, [
-    saveFetcher.state,
-    editKeyFetcher.state,
-    aiFetcher.state,
-    onFetcherStateChange,
-  ]);
 
   const handleTranslationChange = useCallback(
     (locale: string, value: string) => {


### PR DESCRIPTION
## Summary
- Removed the `activeFetchersRef` / `isClosing` / `internalOpen` state machine that tried to wait for pending fetchers before closing the drawer — this was buggy (ref doesn't trigger effects) and unnecessary (fetcher submissions are sent to the server immediately regardless of component unmounting)
- Explicitly blur the active element before closing the drawer so that unsaved translation changes trigger `onBlur` → `saveFetcher.submit()`
- Cleaned up `onFetcherStateChange` callback from `TranslationKeyContent` and `useTranslationKeyEditor`

## Test plan
- [ ] Open a translation key in the drawer
- [ ] Edit a translation value
- [ ] Click the ✕ close button directly (without clicking elsewhere first) — verify the change is saved
- [ ] Click the grey backdrop to close — verify the change is saved
- [ ] Verify the drawer closes immediately in both cases
