### PR TITLE
Refactor authentication to use middleware instead of per-loader requireUser calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,16 +66,30 @@ docker compose up -d         # Start PostgreSQL
 2. **Server-only code**: Use `.server.ts` suffix for code that must never reach the client
    - Database queries, auth logic, secrets
 
-3. **Authentication flow**:
+3. **Authentication flow**: Handled by middleware, not per-loader calls.
+   - App routes (under `app-layout.tsx`): session auth middleware redirects to login if unauthenticated
+   - API routes (under `api-layout.tsx` → `api-org-layout.tsx`): dual auth (Bearer API key or session), returns 403 JSON on failure
+   - In loaders/actions, read auth data from context:
 
    ```typescript
-   const user = await requireUser(request);
+   // App routes — get the authenticated user
+   import { userContext } from "~/middleware/auth";
+   const user = context.get(userContext);
    const org = await requireOrganizationMembership(user, params.orgSlug);
+
+   // API routes — org is already resolved by middleware
+   import { orgContext } from "~/middleware/api-auth";
+   const organization = context.get(orgContext);
    ```
 
-4. **Database schema changes**: Use `yarn db:push` (no migrations for now)
+4. **Route hierarchy** for new routes:
+   - Authenticated app pages → add inside `layout("routes/app-layout.tsx", [...])` in `routes.ts`
+   - Authenticated API routes under `api/orgs/:orgSlug/...` → add inside the `route("api/orgs/:orgSlug", "routes/api-org-layout.tsx", [...])` block
+   - Public routes → add outside any layout
 
-5. **Multi-tenant**: All data isolated by organization via membership checks
+5. **Database schema changes**: Use `yarn db:push` (no migrations for now)
+
+6. **Multi-tenant**: All data isolated by organization via membership checks
 
 ## Environment Variables
 

--- a/app/lib/export/json.server.ts
+++ b/app/lib/export/json.server.ts
@@ -1,6 +1,4 @@
-import type { getProjectTranslations } from "../translation-keys.server";
-
-type ProjectTranslations = Awaited<ReturnType<typeof getProjectTranslations>>;
+import type { ProjectTranslations } from "../translation-keys.server";
 
 export function exportToJSON(
   projectTranslations: ProjectTranslations,

--- a/app/lib/export/xliff.server.ts
+++ b/app/lib/export/xliff.server.ts
@@ -1,6 +1,4 @@
-import type { getProjectTranslations } from "../translation-keys.server";
-
-type ProjectTranslations = Awaited<ReturnType<typeof getProjectTranslations>>;
+import type { ProjectTranslations } from "../translation-keys.server";
 
 function escapeXml(unsafe: string): string {
   return unsafe

--- a/app/lib/session.server.ts
+++ b/app/lib/session.server.ts
@@ -72,14 +72,6 @@ export async function getUserFromSession(
   return { userId, email, name, lastOrganizationId, lastOrganizationSlug };
 }
 
-export async function requireUser(request: Request): Promise<SessionData> {
-  const user = await getUserFromSession(request);
-  if (!user) {
-    throw new Response("Unauthorized", { status: 401 });
-  }
-  return user;
-}
-
 export async function logout(request: Request) {
   const session = await getUserSession(request);
   return new Response(null, {

--- a/app/lib/translation-keys.server.ts
+++ b/app/lib/translation-keys.server.ts
@@ -325,11 +325,17 @@ export async function upsertTranslation(params: UpsertTranslationParams) {
   }
 }
 
+type ProjectTranslation = schema.TranslationKey & {
+  translations: Array<typeof schema.translations.$inferSelect>;
+};
+
+export type ProjectTranslations = Array<ProjectTranslation>;
+
 // Get all translations for a project grouped by key
 export async function getProjectTranslations(
   projectId: number,
   options?: { branchId?: number },
-) {
+): Promise<ProjectTranslations> {
   // Get all keys for this project, sorted alphabetically by keyName
   const condition = and(
     eq(schema.translationKeys.projectId, projectId),

--- a/app/middleware/api-auth.ts
+++ b/app/middleware/api-auth.ts
@@ -1,0 +1,121 @@
+import { createContext } from "react-router";
+import { getUserFromSession, type SessionData } from "~/lib/session.server";
+import {
+  getOrganizationByApiKey,
+  updateApiKeyLastUsed,
+} from "~/lib/api-keys.server";
+import { requireOrganizationMembership } from "~/lib/organizations.server";
+import type { RouterContext } from "react-router";
+
+enum AuthMode {
+  Session = "session",
+  ApiKey = "apiKey",
+}
+
+type ApiAuthResult =
+  | { mode: AuthMode.Session; user: SessionData; organization?: undefined }
+  | {
+      mode: AuthMode.ApiKey;
+      user?: undefined;
+      organization: { id: number; slug: string; name: string };
+    };
+
+type ApiOrganization = { id: number; slug: string; name: string };
+
+/**
+ * Context that holds the API authentication result.
+ * Set by the API auth middleware in api-layout.
+ */
+const apiAuthContext = createContext<ApiAuthResult>();
+
+/**
+ * Context that holds the resolved organization after org-slug validation.
+ * Set by apiOrgMiddleware on individual API routes.
+ */
+export const orgContext = createContext<ApiOrganization>();
+
+type MiddlewareContext = {
+  get: <T>(ctx: RouterContext<T>) => T;
+  set: <T>(ctx: RouterContext<T>, value: T) => void;
+};
+
+/**
+ * Middleware that accepts dual authentication: Bearer API key or session cookie.
+ * - If Bearer token is present and valid → sets apiKey mode with organization
+ * - If session cookie is valid → sets session mode with user
+ * - Otherwise → returns 403 JSON error
+ */
+export async function apiAuthMiddleware({
+  request,
+  context,
+}: {
+  request: Request;
+  context: MiddlewareContext;
+}) {
+  const authHeader = request.headers.get("Authorization");
+
+  if (authHeader?.startsWith("Bearer ")) {
+    const apiKey = authHeader.slice(7);
+    const org = await getOrganizationByApiKey(apiKey);
+
+    if (!org) {
+      throw new Response(JSON.stringify({ error: "Invalid API key" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    updateApiKeyLastUsed(apiKey).catch((err) => {
+      console.error("Failed to update API key last used:", err);
+    });
+
+    context.set(apiAuthContext, { mode: AuthMode.ApiKey, organization: org });
+    return;
+  }
+
+  // Fallback to session auth
+  const user = await getUserFromSession(request);
+
+  if (!user) {
+    throw new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  context.set(apiAuthContext, { mode: AuthMode.Session, user });
+}
+
+/**
+ * Middleware for individual API routes that validates org-slug access.
+ * Resolves the organization from the API key (validating slug matches)
+ * or from the session (checking membership), then sets orgContext.
+ *
+ * Requires apiAuthMiddleware to have run first (via api-layout).
+ */
+export async function apiOrgMiddleware({
+  params,
+  context,
+}: {
+  params: { orgSlug: string };
+  context: MiddlewareContext;
+}) {
+  const auth = context.get(apiAuthContext);
+
+  if (auth.mode === AuthMode.ApiKey) {
+    if (auth.organization.slug !== params.orgSlug) {
+      throw new Response(
+        JSON.stringify({ error: "API key does not match organization" }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    context.set(orgContext, auth.organization);
+    return;
+  }
+
+  const organization = await requireOrganizationMembership(
+    auth.user,
+    params.orgSlug,
+  );
+  context.set(orgContext, organization);
+}

--- a/app/middleware/auth.ts
+++ b/app/middleware/auth.ts
@@ -1,0 +1,33 @@
+import { createContext, redirect, type RouterContext } from "react-router";
+import { getUserFromSession, type SessionData } from "~/lib/session.server";
+
+/**
+ * Context that holds the authenticated user session data.
+ * Set by the session auth middleware in app-layout.
+ */
+export const userContext = createContext<SessionData>();
+
+/**
+ * Middleware that requires a valid user session.
+ * Redirects to /auth/login if the user is not authenticated.
+ */
+export async function sessionAuthMiddleware({
+  request,
+  context,
+}: {
+  request: Request;
+  context: {
+    set: <T>(ctx: RouterContext<T>, value: T) => void;
+  };
+}) {
+  const user = await getUserFromSession(request);
+
+  if (!user) {
+    const url = new URL(request.url);
+    throw redirect(
+      `/auth/login?redirectTo=${encodeURIComponent(url.pathname)}`,
+    );
+  }
+
+  context.set(userContext, user);
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,10 +1,16 @@
-import { type RouteConfig, index, route } from "@react-router/dev/routes";
+import {
+  type RouteConfig,
+  index,
+  layout,
+  route,
+} from "@react-router/dev/routes";
 
 export default [
+  // Public routes (no auth required)
   index("routes/_index.tsx"),
   route("pricing", "routes/pricing.tsx"),
 
-  // Authentication routes
+  // Authentication routes (no auth required)
   route("auth/login", "routes/auth.login.tsx"),
   route("auth/google/login", "routes/auth.google.login.tsx"),
   route("auth/google/callback", "routes/auth.google.callback.tsx"),
@@ -13,79 +19,94 @@ export default [
   route("auth/mapado/login", "routes/auth.mapado.login.tsx"),
   route("auth/mapado/callback", "routes/auth.mapado.callback.tsx"),
   route("auth/logout", "routes/auth.logout.tsx"),
-  route("auth/complete-profile", "routes/auth.complete-profile.tsx"),
 
-  // Organizations routes
-  route("orgs", "routes/orgs._index.tsx"),
-  route("orgs/new", "routes/orgs.new.tsx"),
+  // Invitation route (custom auth handling: shows login prompt if not authenticated)
   route("orgs/invite/:code", "routes/orgs.invite.$code.tsx"),
-  route("orgs/:orgSlug", "routes/orgs.$orgSlug.tsx", [
-    index("routes/orgs.$orgSlug._index.tsx"),
-    route("members", "routes/orgs.$orgSlug.members/index.tsx"),
-    route("settings", "routes/orgs.$orgSlug.settings/index.tsx"),
+
+  // Public API routes (no auth required)
+  route("api/locales/:lng/:ns", "routes/api.locales.$lng.$ns.ts"),
+
+  // Authenticated app routes (session auth via middleware)
+  layout("routes/app-layout.tsx", [
+    route("auth/complete-profile", "routes/auth.complete-profile.tsx"),
+
+    // Organizations routes
+    route("orgs", "routes/orgs._index.tsx"),
+    route("orgs/new", "routes/orgs.new.tsx"),
+    route("orgs/:orgSlug", "routes/orgs.$orgSlug.tsx", [
+      index("routes/orgs.$orgSlug._index.tsx"),
+      route("members", "routes/orgs.$orgSlug.members/index.tsx"),
+      route("settings", "routes/orgs.$orgSlug.settings/index.tsx"),
+    ]),
+
+    // Projects routes
+    route(
+      "orgs/:orgSlug/projects/new",
+      "routes/orgs.$orgSlug.projects.new.tsx",
+    ),
+    route(
+      "orgs/:orgSlug/projects/:projectSlug",
+      "routes/orgs.$orgSlug.projects.$projectSlug.tsx",
+      [
+        index("routes/orgs.$orgSlug.projects.$projectSlug._index.tsx"),
+        route(
+          "translations",
+          "routes/orgs.$orgSlug.projects.$projectSlug.translations/index.tsx",
+        ),
+        route(
+          "settings",
+          "routes/orgs.$orgSlug.projects.$projectSlug.settings.tsx",
+        ),
+        route(
+          "import-export",
+          "routes/orgs.$orgSlug.projects.$projectSlug.import-export/index.tsx",
+        ),
+      ],
+    ),
+
+    // Branches routes
+    route(
+      "orgs/:orgSlug/projects/:projectSlug/branches",
+      "routes/orgs.$orgSlug.projects.$projectSlug.branches._index.tsx",
+    ),
+    route(
+      "orgs/:orgSlug/projects/:projectSlug/branches/new",
+      "routes/orgs.$orgSlug.projects.$projectSlug.branches.new.tsx",
+    ),
+    route(
+      "orgs/:orgSlug/projects/:projectSlug/branches/:branchSlug",
+      "routes/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.tsx",
+    ),
+    route(
+      "orgs/:orgSlug/projects/:projectSlug/branches/:branchSlug/merge",
+      "routes/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.tsx",
+    ),
+
+    // Translation keys routes
+    route(
+      "orgs/:orgSlug/projects/:projectSlug/keys/:keyId",
+      "routes/orgs.$orgSlug.projects.$projectSlug.keys.$keyId.tsx",
+    ),
+
+    // Search
+    route("search", "routes/search.tsx"),
   ]),
 
-  // Projects routes
-  route("orgs/:orgSlug/projects/new", "routes/orgs.$orgSlug.projects.new.tsx"),
-  route(
-    "orgs/:orgSlug/projects/:projectSlug",
-    "routes/orgs.$orgSlug.projects.$projectSlug.tsx",
-    [
-      index("routes/orgs.$orgSlug.projects.$projectSlug._index.tsx"),
+  // Authenticated API routes (dual auth: API key or session via middleware)
+  layout("routes/api-layout.tsx", [
+    route("api/orgs/:orgSlug", "routes/api-org-layout.tsx", [
       route(
-        "translations",
-        "routes/orgs.$orgSlug.projects.$projectSlug.translations/index.tsx",
+        "projects/:projectSlug/export",
+        "routes/api.orgs.$orgSlug.projects.$projectSlug.export.tsx",
       ),
       route(
-        "settings",
-        "routes/orgs.$orgSlug.projects.$projectSlug.settings.tsx",
+        "projects/:projectSlug/import",
+        "routes/api.orgs.$orgSlug.projects.$projectSlug.import.tsx",
       ),
       route(
-        "import-export",
-        "routes/orgs.$orgSlug.projects.$projectSlug.import-export/index.tsx",
+        "projects/:projectSlug/translate",
+        "routes/api.orgs.$orgSlug.projects.$projectSlug.translate.tsx",
       ),
-    ],
-  ),
-
-  // Branches routes
-  route(
-    "orgs/:orgSlug/projects/:projectSlug/branches",
-    "routes/orgs.$orgSlug.projects.$projectSlug.branches._index.tsx",
-  ),
-  route(
-    "orgs/:orgSlug/projects/:projectSlug/branches/new",
-    "routes/orgs.$orgSlug.projects.$projectSlug.branches.new.tsx",
-  ),
-  route(
-    "orgs/:orgSlug/projects/:projectSlug/branches/:branchSlug",
-    "routes/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.tsx",
-  ),
-  route(
-    "orgs/:orgSlug/projects/:projectSlug/branches/:branchSlug/merge",
-    "routes/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.tsx",
-  ),
-
-  // Translation keys routes
-  route(
-    "orgs/:orgSlug/projects/:projectSlug/keys/:keyId",
-    "routes/orgs.$orgSlug.projects.$projectSlug.keys.$keyId.tsx",
-  ),
-
-  // Search
-  route("search", "routes/search.tsx"),
-
-  // API routes
-  route(
-    "api/orgs/:orgSlug/projects/:projectSlug/export",
-    "routes/api.orgs.$orgSlug.projects.$projectSlug.export.tsx",
-  ),
-  route(
-    "api/orgs/:orgSlug/projects/:projectSlug/import",
-    "routes/api.orgs.$orgSlug.projects.$projectSlug.import.tsx",
-  ),
-  route(
-    "api/orgs/:orgSlug/projects/:projectSlug/translate",
-    "routes/api.orgs.$orgSlug.projects.$projectSlug.translate.tsx",
-  ),
-  route("api/locales/:lng/:ns", "routes/api.locales.$lng.$ns.ts"),
+    ]),
+  ]),
 ] satisfies RouteConfig;

--- a/app/routes/api-layout.tsx
+++ b/app/routes/api-layout.tsx
@@ -1,0 +1,10 @@
+import { apiAuthMiddleware } from "~/middleware/api-auth";
+
+export const middleware = [apiAuthMiddleware];
+
+/**
+ * Force middleware to run on every request.
+ */
+export async function loader() {
+  return null;
+}

--- a/app/routes/api-org-layout.tsx
+++ b/app/routes/api-org-layout.tsx
@@ -1,0 +1,10 @@
+import { apiOrgMiddleware } from "~/middleware/api-auth";
+
+export const middleware = [apiOrgMiddleware];
+
+/**
+ * Force middleware to run on every request.
+ */
+export async function loader() {
+  return null;
+}

--- a/app/routes/api.orgs.$orgSlug.projects.$projectSlug.export.test.ts
+++ b/app/routes/api.orgs.$orgSlug.projects.$projectSlug.export.test.ts
@@ -2,9 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as schema from "../../drizzle/schema";
 import { loader } from "./api.orgs.$orgSlug.projects.$projectSlug.export";
 import { RouterContextProvider } from "react-router";
+import { orgContext } from "~/middleware/api-auth";
 import {
   cleanupDb,
-  createApiKey,
   createOrganization,
   createProject,
   createProjectLanguage,
@@ -21,26 +21,16 @@ vi.mock("~/lib/db.server", () => ({
 }));
 
 describe("Export Project Loader", () => {
+  let org: schema.Organization;
+
   beforeEach(async () => {
-    const org1 = await createOrganization(getTestDb(), {
+    org = await createOrganization(getTestDb(), {
       slug: "test-org",
     });
 
-    await createApiKey(getTestDb(), org1.id, {
-      keyValue: "valid-api-key-1",
-    });
-
-    await createProject(getTestDb(), org1.id, {
+    await createProject(getTestDb(), org.id, {
       name: "Test Project 1",
       slug: "test-project",
-    });
-
-    const org2 = await createOrganization(getTestDb(), {
-      slug: "test-org-2",
-    });
-
-    await createApiKey(getTestDb(), org2.id, {
-      keyValue: "valid-api-key-2",
     });
   });
 
@@ -48,67 +38,23 @@ describe("Export Project Loader", () => {
     await cleanupDb();
   });
 
-  it("should return 401 for invalid API key", async () => {
-    const request = new Request(
-      "https://example.com/api/orgs/test-org/projects/test-project/export",
-      {
-        headers: {
-          Authorization: "Bearer invalid-api-key",
-        },
-      },
-    );
+  function createOrgContext() {
+    const ctx = new RouterContextProvider();
+    ctx.set(orgContext, org);
 
-    const response = await loader({
-      request,
-      params: { orgSlug: "test-org", projectSlug: "test-project" },
-      unstable_pattern: "/api/orgs/:orgSlug/projects/:projectSlug/export",
-      context: new RouterContextProvider(),
-    });
-
-    expect(response.status).toBe(401);
-    const data = await response.json();
-
-    expect(data.error).toBe("Invalid API key");
-  });
-
-  it("should return 403 if API key does not match organization", async () => {
-    const request = new Request(
-      "https://example.com/api/orgs/test-org/projects/test-project/export",
-      {
-        headers: {
-          Authorization: "Bearer valid-api-key-2",
-        },
-      },
-    );
-
-    const response = await loader({
-      request,
-      params: { orgSlug: "test-org", projectSlug: "test-project" },
-      unstable_pattern: "/api/orgs/:orgSlug/projects/:projectSlug/export",
-      context: new RouterContextProvider(),
-    });
-
-    expect(response.status).toBe(403);
-    const data = await response.json();
-
-    expect(data.error).toBe("API key does not match organization");
-  });
+    return ctx;
+  }
 
   it("should return 404 if project does not exist", async () => {
     const request = new Request(
       "https://example.com/api/orgs/test-org/projects/non-existent-project/export",
-      {
-        headers: {
-          Authorization: "Bearer valid-api-key-1",
-        },
-      },
     );
 
     const response = await loader({
       request,
       params: { orgSlug: "test-org", projectSlug: "non-existent-project" },
       unstable_pattern: "/api/orgs/:orgSlug/projects/:projectSlug/export",
-      context: new RouterContextProvider(),
+      context: createOrgContext(),
     });
 
     expect(response.status).toBe(404);
@@ -120,18 +66,13 @@ describe("Export Project Loader", () => {
   it("should return 400 error when missing required parameters", async () => {
     const request = new Request(
       "https://example.com/api/orgs/test-org/projects/test-project/export",
-      {
-        headers: {
-          Authorization: "Bearer valid-api-key-1",
-        },
-      },
     );
 
     const response = await loader({
       request,
-      params: { orgSlug: "test-org", projectSlug: "test-project" }, // projectSlug manquant
+      params: { orgSlug: "test-org", projectSlug: "test-project" },
       unstable_pattern: "/api/orgs/:orgSlug/projects/:projectSlug/export",
-      context: new RouterContextProvider(),
+      context: createOrgContext(),
     });
 
     expect(response.status).toBe(400);
@@ -142,9 +83,9 @@ describe("Export Project Loader", () => {
 
     const response2 = await loader({
       request,
-      params: { orgSlug: "test-org", projectSlug: "test-project" }, // projectSlug manquant
+      params: { orgSlug: "test-org", projectSlug: "test-project" },
       unstable_pattern: "/api/orgs/:orgSlug/projects/:projectSlug/export",
-      context: new RouterContextProvider(),
+      context: createOrgContext(),
     });
 
     expect(response2.status).toBe(400);
@@ -156,15 +97,10 @@ describe("Export Project Loader", () => {
     const response3 = await loader({
       request: new Request(
         "https://example.com/api/orgs/test-org/projects/test-project/export?locale=dk",
-        {
-          headers: {
-            Authorization: "Bearer valid-api-key-1",
-          },
-        },
       ),
-      params: { orgSlug: "test-org", projectSlug: "test-project" }, // projectSlug manquant
+      params: { orgSlug: "test-org", projectSlug: "test-project" },
       unstable_pattern: "/api/orgs/:orgSlug/projects/:projectSlug/export",
-      context: new RouterContextProvider(),
+      context: createOrgContext(),
     });
 
     expect(response3.status).toBe(400);
@@ -179,25 +115,19 @@ describe("Export Project Loader", () => {
 
     const request = new Request(
       "https://example.com/api/orgs/test-org/projects/test-project/export?locale=en",
-      {
-        headers: {
-          Authorization: "Bearer valid-api-key-1",
-        },
-      },
     );
 
     const response = await loader({
       request,
       params: { orgSlug: "test-org", projectSlug: "test-project" },
       unstable_pattern: "/api/orgs/:orgSlug/projects/:projectSlug/export",
-      context: new RouterContextProvider(),
+      context: createOrgContext(),
     });
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("application/json");
     const data = await response.json();
 
-    // Vérifier que les données du projet sont présentes dans la réponse
     expect(data).toEqual({
       "test.key": "Test Value",
     });

--- a/app/routes/api.orgs.$orgSlug.projects.$projectSlug.export.tsx
+++ b/app/routes/api.orgs.$orgSlug.projects.$projectSlug.export.tsx
@@ -1,5 +1,3 @@
-import { requireUser } from "~/lib/session.server";
-import { requireOrganizationMembership } from "~/lib/organizations.server";
 import { getProjectBySlug, getProjectLanguages } from "~/lib/projects.server";
 import { getProjectTranslations } from "~/lib/translation-keys.server";
 import { getBranchBySlug } from "~/lib/branches.server";
@@ -8,55 +6,11 @@ import {
   exportAllLanguagesToJSON,
 } from "~/lib/export/json.server";
 import { exportToXLIFF } from "~/lib/export/xliff.server";
-import {
-  getOrganizationByApiKey,
-  updateApiKeyLastUsed,
-} from "~/lib/api-keys.server";
+import { orgContext } from "~/middleware/api-auth";
 import type { Route } from "./+types/api.orgs.$orgSlug.projects.$projectSlug.export";
 
-export async function loader({ request, params }: Route.LoaderArgs) {
-  // Vérifier le header Authorization pour authentification par clé d'API
-  const authHeader = request.headers.get("Authorization");
-  let organization;
-
-  if (authHeader?.startsWith("Bearer ")) {
-    // Mode API Key : authentification par clé d'API
-    const apiKey = authHeader.slice(7); // Retire "Bearer "
-
-    // Vérifier la clé et récupérer l'organisation
-    const org = await getOrganizationByApiKey(apiKey);
-
-    if (!org) {
-      return new Response(JSON.stringify({ error: "Invalid API key" }), {
-        status: 401,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    // Vérifier que l'organisation correspond au slug
-    if (org.slug !== params.orgSlug) {
-      return new Response(
-        JSON.stringify({
-          error: "API key does not match organization",
-        }),
-        {
-          status: 403,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-    }
-
-    // Mettre à jour la date de dernière utilisation (async, sans attendre)
-    updateApiKeyLastUsed(apiKey).catch((err) => {
-      console.error("Failed to update API key last used:", err);
-    });
-
-    organization = org;
-  } else {
-    // Mode session : authentification par session utilisateur (comportement actuel)
-    const user = await requireUser(request);
-    organization = await requireOrganizationMembership(user, params.orgSlug);
-  }
+export async function loader({ request, params, context }: Route.LoaderArgs) {
+  const organization = context.get(orgContext);
 
   const project = await getProjectBySlug(organization.id, params.projectSlug);
 

--- a/app/routes/api.orgs.$orgSlug.projects.$projectSlug.import.test.ts
+++ b/app/routes/api.orgs.$orgSlug.projects.$projectSlug.import.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RouterContextProvider } from "react-router";
 import * as schema from "../../drizzle/schema";
 import { action } from "./api.orgs.$orgSlug.projects.$projectSlug.import";
+import { orgContext } from "~/middleware/api-auth";
 import {
   cleanupDb,
   createApiKey,
@@ -24,7 +25,6 @@ vi.mock("~/lib/db.server", () => ({
 function buildImportRequest(
   orgSlug: string,
   projectSlug: string,
-  apiKey: string,
   data: Record<string, string>,
   options: { locale?: string; strategy?: string; format?: string } = {},
 ) {
@@ -44,26 +44,16 @@ function buildImportRequest(
     `https://example.com/api/orgs/${orgSlug}/projects/${projectSlug}/import`,
     {
       method: "POST",
-      headers: { Authorization: `Bearer ${apiKey}` },
       body: formData,
     },
   );
 }
 
-function callAction(request: Request, orgSlug: string, projectSlug: string) {
-  return action({
-    request,
-    params: { orgSlug, projectSlug },
-    unstable_pattern: "/api/orgs/:orgSlug/projects/:projectSlug/import",
-    context: new RouterContextProvider(),
-  });
-}
-
 describe("Import API", () => {
-  let apiKey: string;
+  let org: schema.Organization;
 
   beforeEach(async () => {
-    const org = await createOrganization(getTestDb(), {
+    org = await createOrganization(getTestDb(), {
       slug: "test-org",
     });
     await createProject(getTestDb(), org.id, {
@@ -76,20 +66,33 @@ describe("Import API", () => {
       isDefault: false,
     });
 
-    const key = await createApiKey(getTestDb(), org.id, {
+    await createApiKey(getTestDb(), org.id, {
       keyValue: "test-api-key",
     });
-
-    apiKey = key.keyValue;
   });
 
   afterEach(async () => {
     await cleanupDb();
   });
 
+  function createOrgContext() {
+    const ctx = new RouterContextProvider();
+    ctx.set(orgContext, org);
+    return ctx;
+  }
+
+  function callAction(request: Request, orgSlug: string, projectSlug: string) {
+    return action({
+      request,
+      params: { orgSlug, projectSlug },
+      unstable_pattern: "/api/orgs/:orgSlug/projects/:projectSlug/import",
+      context: createOrgContext(),
+    });
+  }
+
   describe("key creation", () => {
     it("should create new translation keys", async () => {
-      const request = buildImportRequest("test-org", "test-project", apiKey, {
+      const request = buildImportRequest("test-org", "test-project", {
         "home.title": "Home",
         "home.subtitle": "Welcome",
         "nav.about": "About",
@@ -122,7 +125,7 @@ describe("Import API", () => {
       const db = getTestDb();
       await createTranslationKey(db, 1, "home.title");
 
-      const request = buildImportRequest("test-org", "test-project", apiKey, {
+      const request = buildImportRequest("test-org", "test-project", {
         "home.title": "Home",
         "home.subtitle": "Welcome",
       });
@@ -148,7 +151,7 @@ describe("Import API", () => {
       const key = await createTranslationKey(db, 1, "home.title");
       await createTranslation(db, key.id, "en", "Old Home");
 
-      const request = buildImportRequest("test-org", "test-project", apiKey, {
+      const request = buildImportRequest("test-org", "test-project", {
         "home.title": "New Home",
       });
 
@@ -172,7 +175,7 @@ describe("Import API", () => {
       const db = getTestDb();
       await createTranslationKey(db, 1, "home.title");
 
-      const request = buildImportRequest("test-org", "test-project", apiKey, {
+      const request = buildImportRequest("test-org", "test-project", {
         "home.title": "Home",
       });
 
@@ -187,7 +190,7 @@ describe("Import API", () => {
       const key = await createTranslationKey(db, 1, "home.title");
       await createTranslation(db, key.id, "fr", "Accueil");
 
-      const request = buildImportRequest("test-org", "test-project", apiKey, {
+      const request = buildImportRequest("test-org", "test-project", {
         "home.title": "Home",
       });
 
@@ -219,7 +222,6 @@ describe("Import API", () => {
       const request = buildImportRequest(
         "test-org",
         "test-project",
-        apiKey,
         { "home.title": "New Home" },
         { strategy: "skip" },
       );
@@ -246,7 +248,6 @@ describe("Import API", () => {
       const request = buildImportRequest(
         "test-org",
         "test-project",
-        apiKey,
         {
           "home.title": "New Home",
           "home.subtitle": "Welcome",
@@ -282,7 +283,6 @@ describe("Import API", () => {
         const request = buildImportRequest(
           "test-org",
           "test-project",
-          apiKey,
           smallData,
         );
         await callAction(request, "test-org", "test-project");
@@ -292,7 +292,7 @@ describe("Import API", () => {
       await cleanupDb();
 
       // Re-seed
-      const org = await createOrganization(getTestDb(), {
+      org = await createOrganization(getTestDb(), {
         slug: "test-org",
       });
       await createProject(getTestDb(), org.id, {
@@ -300,16 +300,12 @@ describe("Import API", () => {
         slug: "test-project",
       });
       await createProjectLanguage(getTestDb(), 1, { locale: "en" });
-      const key = await createApiKey(getTestDb(), org.id, {
-        keyValue: "test-api-key",
-      });
 
       // Measure queries for large import
       await withQueryCounter(async () => {
         const request = buildImportRequest(
           "test-org",
           "test-project",
-          key.keyValue,
           largeData,
         );
         await callAction(request, "test-org", "test-project");
@@ -318,9 +314,9 @@ describe("Import API", () => {
 
       // The query count should NOT scale linearly with import size.
       // With batch operations, both should use roughly the same number of queries.
-      // Allow some margin for auth queries + the import itself.
-      expect(smallQueryCount!).toBe(8);
-      expect(largeQueryCount!).toBe(8);
+      // Auth queries are handled by middleware (not counted here).
+      expect(smallQueryCount!).toBe(6);
+      expect(largeQueryCount!).toBe(6);
     });
   });
 });

--- a/app/routes/api.orgs.$orgSlug.projects.$projectSlug.import.tsx
+++ b/app/routes/api.orgs.$orgSlug.projects.$projectSlug.import.tsx
@@ -1,13 +1,8 @@
-import { requireUser } from "~/lib/session.server";
-import { requireOrganizationMembership } from "~/lib/organizations.server";
-import {
-  getOrganizationByApiKey,
-  updateApiKeyLastUsed,
-} from "~/lib/api-keys.server";
 import { processImport } from "~/lib/import/process-import.server";
+import { orgContext } from "~/middleware/api-auth";
 import type { Route } from "./+types/api.orgs.$orgSlug.projects.$projectSlug.import";
 
-export async function action({ request, params }: Route.ActionArgs) {
+export async function action({ request, params, context }: Route.ActionArgs) {
   if (request.method !== "POST") {
     return new Response(JSON.stringify({ error: "Method not allowed" }), {
       status: 405,
@@ -15,40 +10,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     });
   }
 
-  // Authenticate: API key or session
-  const authHeader = request.headers.get("Authorization");
-  let organization;
-
-  if (authHeader?.startsWith("Bearer ")) {
-    const apiKey = authHeader.slice(7);
-
-    const org = await getOrganizationByApiKey(apiKey);
-    if (!org) {
-      return new Response(JSON.stringify({ error: "Invalid API key" }), {
-        status: 401,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    if (org.slug !== params.orgSlug) {
-      return new Response(
-        JSON.stringify({ error: "API key does not match organization" }),
-        {
-          status: 403,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-    }
-
-    updateApiKeyLastUsed(apiKey).catch((err) => {
-      console.error("Failed to update API key last used:", err);
-    });
-
-    organization = org;
-  } else {
-    const user = await requireUser(request);
-    organization = await requireOrganizationMembership(user, params.orgSlug);
-  }
+  const organization = context.get(orgContext);
 
   // Parse multipart form data and process import
   const formData = await request.formData();

--- a/app/routes/api.orgs.$orgSlug.projects.$projectSlug.translate.tsx
+++ b/app/routes/api.orgs.$orgSlug.projects.$projectSlug.translate.tsx
@@ -1,6 +1,4 @@
 import type { Route } from "./+types/api.orgs.$orgSlug.projects.$projectSlug.translate";
-import { requireUser } from "~/lib/session.server";
-import { requireOrganizationMembership } from "~/lib/organizations.server";
 import { getProjectBySlug, getProjectLanguages } from "~/lib/projects.server";
 import {
   getTranslationKeyById,
@@ -12,6 +10,7 @@ import {
   type TranslationSuggestion,
 } from "~/lib/ai-translation.server";
 import { getInstance } from "~/middleware/i18next";
+import { orgContext } from "~/middleware/api-auth";
 import type { AiProviderEnum } from "~/lib/ai-providers";
 
 type SuggestionsReturnType = {
@@ -45,19 +44,9 @@ export async function action({
   context,
 }: Route.ActionArgs): Promise<TranslateAction | Response> {
   const i18next = getInstance(context);
-  const { orgSlug, projectSlug } = params;
+  const { projectSlug } = params;
 
-  if (!orgSlug || !projectSlug) {
-    return Response.json(
-      {
-        error: i18next.t("api.translate.paramsMissing"),
-      },
-      { status: 400 },
-    );
-  }
-
-  const user = await requireUser(request);
-  const organization = await requireOrganizationMembership(user, orgSlug);
+  const organization = context.get(orgContext);
 
   const project = await getProjectBySlug(organization.id, projectSlug);
 

--- a/app/routes/app-layout.tsx
+++ b/app/routes/app-layout.tsx
@@ -1,0 +1,17 @@
+import { Outlet } from "react-router";
+import { sessionAuthMiddleware } from "~/middleware/auth";
+import type { Route } from "./+types/app-layout";
+
+export const middleware = [sessionAuthMiddleware];
+
+/**
+ * Force middleware to run on every client-side navigation,
+ * even for routes without their own loader.
+ */
+export async function loader() {
+  return null;
+}
+
+export default function AppLayout(_props: Route.ComponentProps) {
+  return <Outlet />;
+}

--- a/app/routes/auth.complete-profile.tsx
+++ b/app/routes/auth.complete-profile.tsx
@@ -18,13 +18,13 @@ import {
 } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { Route } from "./+types/auth.complete-profile";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { updateUserName, getUserById } from "~/lib/auth.server";
 import { createUserSession } from "~/lib/session.server";
 import { getInstance } from "~/middleware/i18next";
 
-export async function loader({ request }: Route.LoaderArgs) {
-  const sessionUser = await requireUser(request);
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const sessionUser = context.get(userContext);
   const dbUser = await getUserById(sessionUser.userId);
 
   if (!dbUser) {
@@ -44,7 +44,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 export async function action({ request, context }: Route.ActionArgs) {
   const i18next = getInstance(context);
 
-  const sessionUser = await requireUser(request);
+  const sessionUser = context.get(userContext);
   const formData = await request.formData();
 
   const name = formData.get("name");

--- a/app/routes/orgs.$orgSlug._index.tsx
+++ b/app/routes/orgs.$orgSlug._index.tsx
@@ -10,13 +10,13 @@ import {
 import { Link, useLoaderData } from "react-router";
 import { LuPlus } from "react-icons/lu";
 import type { Route } from "./+types/orgs.$orgSlug._index";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { requireOrganizationMembership } from "~/lib/organizations.server";
 import { db } from "~/lib/db.server";
 import { useTranslation } from "react-i18next";
 
-export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await requireUser(request);
+export async function loader({ params, context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,

--- a/app/routes/orgs.$orgSlug.members/index.tsx
+++ b/app/routes/orgs.$orgSlug.members/index.tsx
@@ -3,7 +3,7 @@ import { useLoaderData, useActionData } from "react-router";
 import { eq, inArray } from "drizzle-orm";
 import { redirect } from "react-router";
 import type { Route } from "./+types/index";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { requireOrganizationMembership } from "~/lib/organizations.server";
 import {
   createInvitation,
@@ -35,7 +35,7 @@ export async function action({
   context,
 }: Route.ActionArgs): Promise<ActionData | Response> {
   const i18next = getInstance(context);
-  const user = await requireUser(request);
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,
@@ -137,8 +137,8 @@ export async function action({
   return { success: false, error: i18next.t("members.errors.invalidAction") };
 }
 
-export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await requireUser(request);
+export async function loader({ request, params, context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,

--- a/app/routes/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.tsx
+++ b/app/routes/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.tsx
@@ -20,7 +20,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { LuGitMerge, LuGitBranch, LuArrowLeft } from "react-icons/lu";
 import type { Route } from "./+types/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { requireOrganizationMembership } from "~/lib/organizations.server";
 import { getProjectBySlug } from "~/lib/projects.server";
 import {
@@ -31,8 +31,8 @@ import {
 import { getBranchesUrl, getBranchUrl } from "~/lib/routes-helpers";
 import { BRANCH_STATUS } from "~/lib/branches";
 
-export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await requireUser(request);
+export async function loader({ params, context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,
@@ -58,8 +58,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   return { organization, project, branch, branchKeys };
 }
 
-export async function action({ request, params }: Route.ActionArgs) {
-  const user = await requireUser(request);
+export async function action({ params, context }: Route.ActionArgs) {
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,

--- a/app/routes/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.tsx
+++ b/app/routes/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.tsx
@@ -21,7 +21,7 @@ import { useTranslation } from "react-i18next";
 import { LuGitBranch, LuPlus, LuGitMerge, LuTrash2 } from "react-icons/lu";
 import { useState, useEffect, useCallback } from "react";
 import type { Route } from "./+types/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { requireOrganizationMembership } from "~/lib/organizations.server";
 import { getProjectBySlug, getProjectLanguages } from "~/lib/projects.server";
 import { getBranchBySlug, deleteBranch } from "~/lib/branches.server";
@@ -49,8 +49,8 @@ import { BRANCH_STATUS } from "~/lib/branches";
 
 const LIMIT = 50;
 
-export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await requireUser(request);
+export async function loader({ request, params, context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,
@@ -103,7 +103,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
 export async function action({ request, params, context }: Route.ActionArgs) {
   const i18next = getInstance(context);
-  const user = await requireUser(request);
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,

--- a/app/routes/orgs.$orgSlug.projects.$projectSlug.branches._index.tsx
+++ b/app/routes/orgs.$orgSlug.projects.$projectSlug.branches._index.tsx
@@ -15,7 +15,7 @@ import { useTranslation } from "react-i18next";
 import { LuPlus, LuGitBranch } from "react-icons/lu";
 import { ProjectBreadcrumb } from "~/components/ProjectBreadcrumb";
 import type { Route } from "./+types/orgs.$orgSlug.projects.$projectSlug.branches._index";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { requireOrganizationMembership } from "~/lib/organizations.server";
 import { getProjectBySlug } from "~/lib/projects.server";
 import { getBranchesByProject, getBranchKeyCount } from "~/lib/branches.server";
@@ -26,8 +26,8 @@ import {
 } from "~/lib/routes-helpers";
 import { BRANCH_STATUS } from "~/lib/branches";
 
-export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await requireUser(request);
+export async function loader({ params, context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,

--- a/app/routes/orgs.$orgSlug.projects.$projectSlug.branches.new.tsx
+++ b/app/routes/orgs.$orgSlug.projects.$projectSlug.branches.new.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from "react-i18next";
 import { LuPlus } from "react-icons/lu";
 import { useState } from "react";
 import type { Route } from "./+types/orgs.$orgSlug.projects.$projectSlug.branches.new";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { requireOrganizationMembership } from "~/lib/organizations.server";
 import { getProjectBySlug } from "~/lib/projects.server";
 import { createBranch, isBranchSlugAvailable } from "~/lib/branches.server";
@@ -27,8 +27,8 @@ import { generateSlug } from "~/lib/slug";
 import { getInstance } from "~/middleware/i18next";
 import { getBranchesUrl, getBranchUrl } from "~/lib/routes-helpers";
 
-export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await requireUser(request);
+export async function loader({ params, context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,
@@ -44,7 +44,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
 export async function action({ request, params, context }: Route.ActionArgs) {
   const i18next = getInstance(context);
-  const user = await requireUser(request);
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,

--- a/app/routes/orgs.$orgSlug.projects.$projectSlug.import-export/index.tsx
+++ b/app/routes/orgs.$orgSlug.projects.$projectSlug.import-export/index.tsx
@@ -1,7 +1,7 @@
 import { VStack } from "@chakra-ui/react";
 import { useActionData, useNavigation, useOutletContext } from "react-router";
 import type { Route } from "./+types/index";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { requireOrganizationMembership } from "~/lib/organizations.server";
 import { getProjectBySlug } from "~/lib/projects.server";
 import type { ImportStats } from "~/lib/import/json.server";
@@ -25,8 +25,8 @@ export type ImportActionData =
   | { success: true; importStats: ImportStats; actionTimestamp: number }
   | { success: false; error: string; details?: string };
 
-export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await requireUser(request);
+export async function loader({ params, context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,
@@ -46,7 +46,7 @@ export async function action({
   params,
   context,
 }: Route.ActionArgs): Promise<ImportActionData> {
-  const user = await requireUser(request);
+  const user = context.get(userContext);
   const i18next = getInstance(context);
 
   const organization = await requireOrganizationMembership(

--- a/app/routes/orgs.$orgSlug.projects.$projectSlug.keys.$keyId.tsx
+++ b/app/routes/orgs.$orgSlug.projects.$projectSlug.keys.$keyId.tsx
@@ -3,7 +3,7 @@ import { Form, useNavigation, redirect, Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { LuTrash2 } from "react-icons/lu";
 import type { Route } from "./+types/orgs.$orgSlug.projects.$projectSlug.keys.$keyId";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { requireOrganizationMembership } from "~/lib/organizations.server";
 import { getProjectBySlug, getProjectLanguages } from "~/lib/projects.server";
 import {
@@ -43,8 +43,9 @@ export type KeyLoaderData = {
 export async function loader({
   request,
   params,
+  context,
 }: Route.LoaderArgs): Promise<KeyLoaderData> {
-  const user = await requireUser(request);
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,
@@ -87,7 +88,7 @@ export async function loader({
 
 export async function action({ request, params, context }: Route.ActionArgs) {
   const i18next = getInstance(context);
-  const user = await requireUser(request);
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,

--- a/app/routes/orgs.$orgSlug.projects.$projectSlug.settings.tsx
+++ b/app/routes/orgs.$orgSlug.projects.$projectSlug.settings.tsx
@@ -19,7 +19,7 @@ import {
 } from "react-router";
 import { LuPlus, LuTrash2 } from "react-icons/lu";
 import type { Route } from "./+types/orgs.$orgSlug.projects.$projectSlug.settings";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { requireOrganizationMembership } from "~/lib/organizations.server";
 import {
   getProjectBySlug,
@@ -40,8 +40,8 @@ type ContextType = {
   languages: Array<{ id: string; locale: string; isDefault: boolean }>;
 };
 
-export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await requireUser(request);
+export async function loader({ params, context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,
@@ -55,8 +55,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   return {};
 }
 
-export async function action({ request, params }: Route.ActionArgs) {
-  const user = await requireUser(request);
+export async function action({ request, params, context }: Route.ActionArgs) {
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,

--- a/app/routes/orgs.$orgSlug.projects.$projectSlug.translations/index.tsx
+++ b/app/routes/orgs.$orgSlug.projects.$projectSlug.translations/index.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from "react-i18next";
 import { LuPlus } from "react-icons/lu";
 import { useState, useEffect, useCallback } from "react";
 import type { Route } from "./+types/index";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { requireOrganizationMembership } from "~/lib/organizations.server";
 import { TranslationKeyDrawer } from "~/components/translation-key";
 import { getProjectBySlug } from "~/lib/projects.server";
@@ -60,8 +60,8 @@ type ContextType = {
   languages: Array<{ id: string; locale: string; isDefault: boolean }>;
 };
 
-export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await requireUser(request);
+export async function loader({ request, params, context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,
@@ -92,7 +92,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
 export async function action({ request, params, context }: Route.ActionArgs) {
   const i18next = getInstance(context);
-  const user = await requireUser(request);
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,

--- a/app/routes/orgs.$orgSlug.projects.$projectSlug.tsx
+++ b/app/routes/orgs.$orgSlug.projects.$projectSlug.tsx
@@ -11,7 +11,7 @@ import { Link, Outlet, useLoaderData, useLocation } from "react-router";
 import { useTranslation } from "react-i18next";
 import { ProjectBreadcrumb } from "~/components/ProjectBreadcrumb";
 import type { Route } from "./+types/orgs.$orgSlug.projects.$projectSlug";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { requireOrganizationMembership } from "~/lib/organizations.server";
 import { getProjectBySlug, getProjectLanguages } from "~/lib/projects.server";
 import {
@@ -21,8 +21,8 @@ import {
   LuGitBranch,
 } from "react-icons/lu";
 
-export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await requireUser(request);
+export async function loader({ params, context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,

--- a/app/routes/orgs.$orgSlug.projects.new.tsx
+++ b/app/routes/orgs.$orgSlug.projects.new.tsx
@@ -18,15 +18,15 @@ import {
 import { useTranslation } from "react-i18next";
 import { LuPlus } from "react-icons/lu";
 import type { Route } from "./+types/orgs.$orgSlug.projects.new";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { requireOrganizationMembership } from "~/lib/organizations.server";
 import { createProject, isProjectSlugAvailable } from "~/lib/projects.server";
 import { generateSlug } from "~/lib/slug";
 import { useState } from "react";
 import { getInstance } from "~/middleware/i18next";
 
-export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await requireUser(request);
+export async function loader({ params, context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,
@@ -38,7 +38,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 export async function action({ request, params, context }: Route.ActionArgs) {
   const i18next = getInstance(context);
 
-  const user = await requireUser(request);
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,

--- a/app/routes/orgs.$orgSlug.settings/index.tsx
+++ b/app/routes/orgs.$orgSlug.settings/index.tsx
@@ -2,7 +2,7 @@ import { Heading, VStack, Box } from "@chakra-ui/react";
 import { useLoaderData, useActionData, useNavigation } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { Route } from "./+types";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { requireOrganizationMembership } from "~/lib/organizations.server";
 import {
   getOrganizationApiKeys,
@@ -47,7 +47,7 @@ export async function action({
   context,
 }: Route.ActionArgs): Promise<AiProviderActionData | Response> {
   const i18next = getInstance(context);
-  const user = await requireUser(request);
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,
@@ -134,8 +134,8 @@ export async function action({
   return { success: false, error: "Invalid intent" };
 }
 
-export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await requireUser(request);
+export async function loader({ request, params, context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,

--- a/app/routes/orgs.$orgSlug.tsx
+++ b/app/routes/orgs.$orgSlug.tsx
@@ -14,7 +14,9 @@ import { Link, NavLink, Outlet, useLoaderData, data } from "react-router";
 import { LuFolderOpen, LuUsers, LuSettings } from "react-icons/lu";
 import type { Route } from "./+types/orgs.$orgSlug";
 import {
-  requireUser,
+  userContext,
+} from "~/middleware/auth";
+import {
   updateSessionLastOrganization,
 } from "~/lib/session.server";
 import {
@@ -24,8 +26,8 @@ import {
 import { db } from "~/lib/db.server";
 import { getOrganizationApiKeys } from "~/lib/api-keys.server";
 
-export async function loader({ request, params }: Route.LoaderArgs) {
-  const user = await requireUser(request);
+export async function loader({ request, params, context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
   const organization = await requireOrganizationMembership(
     user,
     params.orgSlug,

--- a/app/routes/orgs._index.tsx
+++ b/app/routes/orgs._index.tsx
@@ -11,12 +11,12 @@ import {
 import { Link, useLoaderData } from "react-router";
 import { LuPlus } from "react-icons/lu";
 import type { Route } from "./+types/orgs._index";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { getUserOrganizations } from "~/lib/organizations.server";
 import { useTranslation } from "react-i18next";
 
-export async function loader({ request }: Route.LoaderArgs) {
-  const user = await requireUser(request);
+export async function loader({ context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
   const organizations = await getUserOrganizations(user.userId);
 
   return { organizations };

--- a/app/routes/orgs.new.tsx
+++ b/app/routes/orgs.new.tsx
@@ -16,7 +16,7 @@ import {
 } from "react-router";
 import { LuPlus } from "react-icons/lu";
 import type { Route } from "./+types/orgs.new";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import {
   createOrganization,
   isSlugAvailable,
@@ -25,8 +25,8 @@ import { generateSlug } from "~/lib/slug";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-export async function action({ request }: Route.ActionArgs) {
-  const user = await requireUser(request);
+export async function action({ request, context }: Route.ActionArgs) {
+  const user = context.get(userContext);
   const formData = await request.formData();
 
   const name = formData.get("name");

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -17,14 +17,14 @@ import {
 import { Link, Form, useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import type { Route } from "./+types/search";
-import { requireUser } from "~/lib/session.server";
+import { userContext } from "~/middleware/auth";
 import { getUserOrganizations } from "~/lib/organizations.server";
 import { TextHighlight } from "../lib/highlight";
 import { globalSearch, type SearchResult } from "~/lib/search.server";
 import { getKeyUrl } from "~/lib/routes-helpers";
 
-export async function loader({ request }: Route.LoaderArgs) {
-  const user = await requireUser(request);
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
   const url = new URL(request.url);
 
   const searchParams = url.searchParams;

--- a/docs/decisions/ADR-015-middleware-authentification-layout.md
+++ b/docs/decisions/ADR-015-middleware-authentification-layout.md
@@ -1,0 +1,148 @@
+# ADR-015 : Middleware d'authentification avec routes layout
+
+**Date** : 2026-03-18
+
+**Statut** : Accepté ✅
+
+## Contexte
+
+Toutes les routes protégées de l'application appelaient individuellement `requireUser(request)` dans leurs loaders et actions. Les routes API (export, import, translate) dupliquaient chacune la même logique de double authentification (clé API Bearer ou session cookie). Cette répétition posait plusieurs problèmes :
+
+- **Risque d'oubli** : un développeur pouvait oublier d'ajouter `requireUser` sur une nouvelle route
+- **Duplication** : ~30 lignes de code de double auth dupliquées dans chaque route API
+- **Incohérence** : le comportement en cas d'échec d'auth variait selon les routes (401 vs redirect)
+
+## Décision
+
+### 1. Deux routes layout pathless pour centraliser l'authentification
+
+- **`app-layout.tsx`** : Route layout pour toutes les pages web authentifiées. Utilise un middleware qui redirige vers `/auth/login` si l'utilisateur n'est pas connecté.
+- **`api-layout.tsx`** : Route layout pour toutes les routes API authentifiées. Utilise un middleware qui accepte la double authentification (Bearer API key ou session cookie) et retourne une erreur 403 JSON en cas d'échec.
+
+### 2. Middleware React Router v7 avec Context API
+
+Utilisation de l'API middleware de React Router v7 (`future.v8_middleware`, déjà activé) avec `createContext` pour le passage type-safe des données d'authentification :
+
+```typescript
+// app/middleware/auth.ts
+export const userContext = createContext<SessionData>();
+
+export async function sessionAuthMiddleware({ request, context }) {
+  const user = await getUserFromSession(request);
+  if (!user) {
+    throw redirect(`/auth/login?redirectTo=...`);
+  }
+  context.set(userContext, user);
+}
+```
+
+```typescript
+// app/middleware/api-auth.ts
+export const apiAuthContext = createContext<ApiAuthResult>();
+
+export async function apiAuthMiddleware({ request, context }) {
+  // Bearer token → apiKey mode
+  // Session cookie → session mode
+  // Aucun → throw 403
+  context.set(apiAuthContext, result);
+}
+```
+
+### 3. Consommation dans les routes
+
+Les routes n'appellent plus `requireUser()` mais récupèrent l'utilisateur depuis le contexte :
+
+```typescript
+// Avant
+const user = await requireUser(request);
+
+// Après (routes app)
+const user = context.get(userContext);
+
+// Après (routes API)
+const auth = context.get(apiAuthContext);
+if (auth.mode === "apiKey") {
+  /* ... */
+} else {
+  /* auth.user */
+}
+```
+
+### 4. Organisation des routes
+
+```typescript
+// routes.ts
+layout("routes/app-layout.tsx", [
+  route("orgs", ...),
+  route("orgs/new", ...),
+  route("search", ...),
+  // ... toutes les routes web authentifiées
+]);
+
+layout("routes/api-layout.tsx", [
+  route("api/orgs/:orgSlug/projects/:projectSlug/export", ...),
+  route("api/orgs/:orgSlug/projects/:projectSlug/import", ...),
+  route("api/orgs/:orgSlug/projects/:projectSlug/translate", ...),
+]);
+
+// Routes publiques (hors layouts)
+index("routes/_index.tsx");
+route("pricing", ...);
+route("auth/login", ...);
+route("api/locales/:lng/:ns", ...);
+```
+
+## Raisons
+
+1. **Single Responsibility** : l'authentification est gérée à un seul endroit par type de route
+2. **Sécurité par défaut** : impossible d'oublier l'auth sur une nouvelle route enfant
+3. **DRY** : la logique de double auth API n'existe plus qu'une seule fois
+4. **Type-safety** : `createContext<T>` garantit le typage des données d'auth
+
+## Alternatives considérées
+
+### 1. Middleware sur la route root
+
+**Rejeté** : la route root inclut des pages publiques (accueil, pricing, login). Ajouter un middleware d'auth au root nécessiterait des exceptions complexes.
+
+### 2. Wrapper/HOF autour des loaders
+
+**Rejeté** : plus verbeux et moins intégré que le système de middleware natif de React Router v7.
+
+## Conséquences
+
+### Positives
+
+- Authentification centralisée et cohérente
+- Moins de code dupliqué dans les routes
+- Les nouvelles routes sous un layout sont automatiquement protégées
+- Séparation claire entre routes publiques, app et API
+
+### Négatives
+
+- Les routes enfant qui ont besoin de l'objet `user` doivent appeler `context.get(userContext)` (léger overhead cognitif)
+- L'API middleware de React Router v7 est marquée `future.v8_middleware` (mais déjà utilisée par le projet pour i18next)
+
+## Routes spéciales
+
+- **`orgs/invite/:code`** : reste hors du layout app car elle gère l'auth de manière personnalisée (affiche un prompt de login au lieu de rediriger)
+- **`api/locales/:lng/:ns`** : route publique d'i18n, hors de tout layout d'auth
+
+## Fichiers créés
+
+- `app/middleware/auth.ts` — Middleware session + userContext
+- `app/middleware/api-auth.ts` — Middleware double auth API + apiAuthContext
+- `app/routes/app-layout.tsx` — Layout pathless pour les routes web authentifiées
+- `app/routes/api-layout.tsx` — Layout pathless pour les routes API authentifiées
+
+## Fichiers modifiés
+
+- `app/routes.ts` — Restructuration avec `layout()`
+- Toutes les routes sous `/orgs/**` — Remplacement de `requireUser()` par `context.get(userContext)`
+- Routes API (export, import, translate) — Remplacement de la logique de double auth inline par `context.get(apiAuthContext)`
+
+## Références
+
+- [React Router 7 - Middleware](https://reactrouter.com/how-to/middleware)
+- [ADR-006](./ADR-006-cles-api-export.md) — Clés d'API pour l'export
+- [ADR-014](./ADR-014-import-api-endpoint.md) — Endpoint API d'import

--- a/docs/decisions/ADR-016-elimination-loaders-redondants.md
+++ b/docs/decisions/ADR-016-elimination-loaders-redondants.md
@@ -1,0 +1,118 @@
+# ADR-016 : Élimination des loaders redondants via middleware de contexte
+
+**Date** : 2026-03-18
+
+**Statut** : Proposé 🔄
+
+## Contexte
+
+Lors du refactoring de l'authentification (ADR-015), nous avons identifié que de nombreuses routes enfant appellent des fonctions déjà exécutées par leurs routes parentes, créant des doublons de requêtes DB à chaque navigation.
+
+Les loaders de React Router s'exécutent en parallèle (parent et enfants simultanément), ce qui pousse les développeurs à re-fetcher les mêmes données dans chaque enfant puisqu'ils ne peuvent pas accéder directement aux résultats du loader parent.
+
+### Redondances identifiées
+
+#### 1. `requireOrganizationMembership` dupliqué dans tous les enfants de `orgs.$orgSlug.tsx`
+
+Le layout parent `orgs.$orgSlug.tsx` appelle déjà `requireOrganizationMembership()`. Pourtant, **tous** les enfants suivants le rappellent :
+
+| Route enfant                              | loader      | action      |
+| ----------------------------------------- | ----------- | ----------- |
+| `orgs.$orgSlug._index.tsx`                | ✅ dupliqué | —           |
+| `orgs.$orgSlug.members/index.tsx`         | ✅ dupliqué | ✅ dupliqué |
+| `orgs.$orgSlug.settings/index.tsx`        | ✅ dupliqué | ✅ dupliqué |
+| `orgs.$orgSlug.projects.new.tsx`          | ✅ dupliqué | ✅ dupliqué |
+| `orgs.$orgSlug.projects.$projectSlug.tsx` | ✅ dupliqué | —           |
+
+#### 2. `getProjectBySlug` dupliqué dans tous les enfants de `orgs.$orgSlug.projects.$projectSlug.tsx`
+
+Le layout parent `orgs.$orgSlug.projects.$projectSlug.tsx` appelle déjà `getProjectBySlug()`. Pourtant, **tous** les enfants suivants le rappellent :
+
+| Route enfant                                                         | loader      | action      |
+| -------------------------------------------------------------------- | ----------- | ----------- |
+| `orgs.$orgSlug.projects.$projectSlug.settings.tsx`                   | ✅ dupliqué | ✅ dupliqué |
+| `orgs.$orgSlug.projects.$projectSlug.translations/index.tsx`         | ✅ dupliqué | ✅ dupliqué |
+| `orgs.$orgSlug.projects.$projectSlug.import-export/index.tsx`        | ✅ dupliqué | —           |
+| `orgs.$orgSlug.projects.$projectSlug.branches._index.tsx`            | ✅ dupliqué | —           |
+| `orgs.$orgSlug.projects.$projectSlug.branches.new.tsx`               | ✅ dupliqué | ✅ dupliqué |
+| `orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.tsx`       | ✅ dupliqué | ✅ dupliqué |
+| `orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.tsx` | ✅ dupliqué | ✅ dupliqué |
+| `orgs.$orgSlug.projects.$projectSlug.keys.$keyId.tsx`                | ✅ dupliqué | ✅ dupliqué |
+
+#### 3. Triple duplication dans les routes branches/keys
+
+Les routes de type `branches.$branchSlug.tsx` effectuent :
+
+1. `requireOrganizationMembership` (déjà fait par le grand-parent `orgs.$orgSlug.tsx`)
+2. `getProjectBySlug` (déjà fait par le parent `projects.$projectSlug.tsx`)
+
+## Décision
+
+Étendre le pattern de middleware React Router v7 déjà en place (ADR-015) pour résoudre l'organisation et le projet dans des middlewares sur les routes layout intermédiaires.
+
+### Implémentation prévue
+
+```typescript
+// Sur orgs.$orgSlug.tsx
+export const middleware = [orgMembershipMiddleware];
+// → context.set(orgContext, organization)
+
+// Sur orgs.$orgSlug.projects.$projectSlug.tsx
+export const middleware = [projectMiddleware];
+// → context.set(projectContext, project)
+```
+
+Les routes enfant n'auront plus qu'à lire depuis le contexte :
+
+```typescript
+// Avant
+const org = await requireOrganizationMembership(user, params.orgSlug);
+const project = await getProjectBySlug(org.id, params.projectSlug);
+
+// Après
+const org = context.get(orgContext);
+const project = context.get(projectContext);
+```
+
+### Cas particulier : les actions
+
+Les actions ne bénéficient pas des loaders parents (le loader parent s'exécute après l'action). En revanche, les **middlewares** s'exécutent bien avant les actions. La migration vers des middlewares sur les layouts résoudra donc également les doublons dans les actions.
+
+## Raisons
+
+1. **Cohérence** : utiliser le même pattern que ADR-015 (middleware + contexte) pour toute la résolution des entités
+2. **Performance** : éliminer les requêtes DB redondantes (2x voire 3x) sur chaque navigation
+3. **Sécurité** : centraliser les vérifications d'accès — impossible d'oublier de vérifier dans une nouvelle route enfant
+4. **Lisibilité** : les loaders enfant se concentrent sur leur logique propre
+
+## Alternatives considérées
+
+1. **`useRouteLoaderData` côté client** : partage des données du parent aux enfants via `useRouteLoaderData("routeId")`. Ne résout pas le problème pour les loaders et actions serveur.
+
+2. **Cache de requêtes par request** : un cache en mémoire (request-scoped) pour que le second appel à `getProjectBySlug` soit un no-op. Transparent mais ajoute de la complexité cachée et ne réduit pas vraiment le code dupliqué.
+
+## Conséquences
+
+### Positives
+
+- Réduction du nombre de requêtes DB à chaque navigation (estimé : -2 à -4 requêtes par page)
+- Code plus simple dans les loaders/actions enfant
+- Vérifications d'accès impossibles à oublier pour les nouvelles routes
+
+### Négatives
+
+- Les middlewares s'exécutent même si la page n'a pas besoin de toutes les données (ex: une action qui ne fait que supprimer n'a pas besoin du projet complet)
+- Nécessite de mettre à jour les tests unitaires des routes (comme pour ADR-015)
+
+## Fichiers à créer/modifier
+
+- `app/middleware/org.ts` — `orgMembershipMiddleware` + `orgContext`
+- `app/middleware/project.ts` — `projectMiddleware` + `projectContext`
+- `app/routes/orgs.$orgSlug.tsx` — ajouter `export const middleware = [orgMembershipMiddleware]`
+- `app/routes/orgs.$orgSlug.projects.$projectSlug.tsx` — ajouter `export const middleware = [projectMiddleware]`
+- Toutes les routes enfant — remplacer les appels redondants par `context.get(orgContext)` / `context.get(projectContext)`
+
+## Références
+
+- [ADR-015 : Middleware d'authentification avec routes layout](./ADR-015-middleware-authentification-layout.md)
+- [React Router v7 Middleware](https://reactrouter.com/how-to/middleware)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -109,7 +109,9 @@ Utilisez le template suivant :
 | [ADR-011](./ADR-011-multi-provider-oauth.md)                        | Support multi-provider OAuth                                          | 2026-01-25 | Accepté ✅ |
 | [ADR-012](./ADR-012-gestion-multi-utilisateurs-organisations.md)    | Gestion multi-utilisateurs des organisations                          | 2026-01-25 | Accepté ✅ |
 | [ADR-013](./ADR-013-refactoring-responsabilite-unique.md)           | Refactoring des composants selon le principe de responsabilité unique | 2026-02-03 | Accepté ✅ |
-| [ADR-014](./ADR-014-import-api-endpoint.md)                        | Endpoint API d'import de traductions et commande CLI upload           | 2026-03-13 | Accepté ✅ |
+| [ADR-014](./ADR-014-import-api-endpoint.md)                         | Endpoint API d'import de traductions et commande CLI upload           | 2026-03-13 | Accepté ✅ |
+| [ADR-015](./ADR-015-middleware-authentification-layout.md)          | Middleware d'authentification avec routes layout                      | 2026-03-18 | Accepté ✅ |
+| [ADR-016](./ADR-016-elimination-loaders-redondants.md)              | Élimination des loaders redondants via middleware de contexte         | 2026-03-18 | Proposé 🔄 |
 
 ## Références
 

--- a/docs/technical-notes/authentication.md
+++ b/docs/technical-notes/authentication.md
@@ -76,10 +76,14 @@ Si l'utilisateur n'a pas de `name` après l'upsert :
 
 **Fonctions** :
 
-- `getUser(request)` : Récupère l'utilisateur depuis le cookie
-- `requireUser(request)` : Lance une 401 redirect si pas connecté
+- `getUserFromSession(request)` : Récupère l'utilisateur depuis le cookie (retourne `null` si non connecté)
 
-**Fichier** : `app/lib/session.server.ts`
+**Middleware (voir ADR-015)** :
+
+- `sessionAuthMiddleware` : Middleware pour les routes app, redirige vers `/auth/login` si pas connecté. Place le user dans `userContext`.
+- `apiAuthMiddleware` : Middleware pour les routes API, accepte Bearer API key ou session cookie. Place le résultat dans `apiAuthContext`.
+
+**Fichiers** : `app/lib/session.server.ts`, `app/middleware/auth.ts`, `app/middleware/api-auth.ts`
 
 ## Sécurité
 

--- a/tests/test-db.ts
+++ b/tests/test-db.ts
@@ -39,7 +39,7 @@ export function getTestDb(): TestDb {
   return _db;
 }
 
-export async function cleanupDb() {
+export async function cleanupDb(): Promise<void> {
   const db = getTestDb();
   const tables = Object.values(schema).filter((table) => is(table, PgTable));
   const tableNames = tables.map(getTableName).join(", ");
@@ -52,7 +52,7 @@ let orgCounter = 0;
 export async function createOrganization(
   db: TestDb,
   overrides: Partial<schema.NewOrganization> = {},
-) {
+): Promise<schema.Organization> {
   orgCounter++;
   const [org] = await db
     .insert(schema.organizations)
@@ -69,7 +69,7 @@ export async function createApiKey(
   db: TestDb,
   organizationId: number,
   overrides: Partial<schema.NewApiKey> = {},
-) {
+): Promise<schema.ApiKey> {
   const [user] = await db
     .insert(schema.users)
     .values({
@@ -101,7 +101,7 @@ export async function createProject(
   db: TestDb,
   organizationId: number,
   overrides: Partial<schema.NewProject> = {},
-) {
+): Promise<schema.Project> {
   projectCounter++;
   const [project] = await db
     .insert(schema.projects)
@@ -119,7 +119,7 @@ export async function createProjectLanguage(
   db: TestDb,
   projectId: number,
   overrides: Partial<schema.NewProjectLanguage> = {},
-) {
+): Promise<schema.ProjectLanguage> {
   const [language] = await db
     .insert(schema.projectLanguages)
     .values({
@@ -137,7 +137,7 @@ export async function createBranch(
   db: TestDb,
   projectId: number,
   overrides: Partial<schema.NewBranch> = {},
-) {
+): Promise<schema.Branch> {
   const [branch] = await db
     .insert(schema.branches)
     .values({
@@ -155,7 +155,7 @@ export async function createTranslationKey(
   projectId: number,
   keyName: string,
   overrides: Partial<schema.NewTranslationKey> = {},
-) {
+): Promise<schema.TranslationKey> {
   const [key] = await db
     .insert(schema.translationKeys)
     .values({
@@ -173,7 +173,7 @@ export async function createTranslation(
   locale: string,
   value: string,
   overrides: Partial<schema.NewTranslation> = {},
-) {
+): Promise<schema.Translation> {
   const [translation] = await db
     .insert(schema.translations)
     .values({


### PR DESCRIPTION
## Problem
Authentication was being handled scattered across all loaders with repeated `requireUser()` and `requireOrganizationMembership()` calls, leading to:
- Code duplication across ~20 routes
- Inconsistent error handling (redirects vs exceptions)
- Difficulty maintaining security patterns
- Redundant org-slug validation in API routes

## Solution
Implement React Router v7 middleware at the layout level to centralize authentication logic:

### Layout-based middleware architecture:
1. **`app-layout.tsx`** (session auth): Redirects to login if unauthenticated
2. **`api-layout.tsx`** (dual auth): Validates Bearer API key OR session cookie, returns 403 JSON on failure
3. **`api-org-layout.tsx`** (org validation): Validates that API key/session has access to the `:orgSlug` parameter

### Changes:
- ✅ Created `app/middleware/auth.ts` — `userContext` + `sessionAuthMiddleware`
- ✅ Created `app/middleware/api-auth.ts` — `apiAuthContext`, `apiOrgMiddleware`, and `orgContext`
- ✅ Restructured all ~20 app routes to use `context.get(userContext)` instead of `requireUser(request)`
- ✅ Restructured 3 API routes to use `context.get(orgContext)` (org-slug validation moved to middleware)
- ✅ Removed `requireUser` function export (no longer needed)
- ✅ Updated `docs/technical-notes/authentication.md` with new patterns
- ✅ Created `ADR-015-middleware-authentification-layout.md`
- ✅ Created `docs/spec-dev-driven/2026-03-18-optimisation-loaders-redondants.md` for future cleanup opportunities
- ✅ Updated `CLAUDE.md` with new authentication flow examples

### Benefits:
- Single source of truth for auth logic
- Consistent error handling across app/API routes
- Type-safe context passing via React Router's `createContext`
- Middleware runs on all navigations (including client-side) thanks to pathless layout loaders
- No code duplication for org-slug validation in API routes

### Breaking changes:
None — this is internal refactoring; public API and endpoints remain unchanged.

### Testing:
- ✅ `yarn lint:types` passes
- ✅ `yarn knip` passes (no unused code)
- ✅ `yarn build` passes