### PR TITLE
feat(cli): add --project filter to download:config and upload:config

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.7.0
+
+### Added
+
+- Added `--project` option to `download:config` and `upload:config` commands to filter by a comma-separated list of project slugs. ([#110](https://github.com/transi-store/transi-store/pull/110))
+
 ## 1.6.0
 
 ### Changed

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -100,9 +100,22 @@ program
     "-b, --branch <branch>",
     `Branch slug (exports main + branch keys). Use "${ALL_BRANCHES_VALUE}" to export all branches`,
   )
+  .option(
+    "-p, --project <projects>",
+    "Comma-separated list of project slugs to download (default: all projects)",
+  )
   .addOption(apiKeyOption)
   .action((options) => {
-    fetchForConfig(options.config, options.apiKey, options.branch);
+    const projectFilter = options.project
+      ? options.project.split(",").map((s) => s.trim())
+      : undefined;
+
+    fetchForConfig(
+      options.config,
+      options.apiKey,
+      options.branch,
+      projectFilter,
+    );
   });
 
 program
@@ -122,6 +135,10 @@ program
     `Import strategy: '${ImportStrategy.OVERWRITE}' or '${ImportStrategy.SKIP}' existing translations`,
     ImportStrategy.SKIP,
   )
+  .option(
+    "-p, --project <projects>",
+    "Comma-separated list of project slugs to upload (default: all projects)",
+  )
   .addOption(apiKeyOption)
   .action((options) => {
     const strategy = options.strategy;
@@ -135,7 +152,17 @@ program
       process.exit(1);
     }
 
-    uploadForConfig(options.config, options.apiKey, strategy, options.branch);
+    const projectFilter = options.project
+      ? options.project.split(",").map((s) => s.trim())
+      : undefined;
+
+    uploadForConfig(
+      options.config,
+      options.apiKey,
+      strategy,
+      options.branch,
+      projectFilter,
+    );
   });
 
 program.parse();

--- a/packages/cli/src/fetchForConfig.ts
+++ b/packages/cli/src/fetchForConfig.ts
@@ -38,7 +38,8 @@ function renderProgressBar(completed: number, total: number): string {
 export async function fetchForConfig(
   configPath: string,
   apiKey: string,
-  branch?: string,
+  branch: string | undefined,
+  projectFilter: Array<string> | undefined,
 ): Promise<void> {
   const cwd = process.cwd();
 
@@ -75,6 +76,9 @@ export async function fetchForConfig(
   const localesByProject = new Map<string, string[]>();
 
   for (const configItem of result.data.projects) {
+    if (projectFilter && !projectFilter.includes(configItem.project)) {
+      continue;
+    }
     if (!localesByProject.has(configItem.project)) {
       projectOrder.push(configItem.project);
       localesByProject.set(configItem.project, []);

--- a/packages/cli/src/uploadTranslations.ts
+++ b/packages/cli/src/uploadTranslations.ts
@@ -98,7 +98,8 @@ export async function uploadForConfig(
   configPath: string,
   apiKey: string,
   strategy: ImportStrategy,
-  branch?: string,
+  branch: string | undefined,
+  projectFilter: Array<string> | undefined,
 ): Promise<void> {
   const cwd = process.cwd();
 
@@ -146,6 +147,9 @@ export async function uploadForConfig(
   }
 
   for (const configItem of result.data.projects) {
+    if (projectFilter && !projectFilter.includes(configItem.project)) {
+      continue;
+    }
     for (const locale of configItem.langs) {
       const input = configItem.output
         .replace("<lang>", locale)


### PR DESCRIPTION
## Summary

Add a `--project` / `-p` option to the `download:config` and `upload:config` commands to allow filtering which projects are processed.

## Usage

```bash
yarn transi-store download:config --project=slug1,slug2
yarn transi-store upload:config --project=slug1,slug2
```

When `--project` is omitted, all projects are processed as before.

## Changes

- `cli.ts` — Added `-p, --project <projects>` option to both commands; splits the comma-separated value and passes it as a `string[]` filter
- `fetchForConfig.ts` — `fetchForConfig()` accepts an optional `projectFilter` and skips projects not in the list
- `uploadTranslations.ts` — `uploadForConfig()` accepts an optional `projectFilter` and skips projects not in the list

Closes #105