### PR TITLE
XLIFF: use <source> if name attribute is not set

### DIFF
--- a/apps/website/app/lib/format/xliff-format.server.test.ts
+++ b/apps/website/app/lib/format/xliff-format.server.test.ts
@@ -174,6 +174,34 @@ describe("XliffTranslationFormat", () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain("trop volumineux");
     });
+
+    it('should use "source" if name is not defined', () => {
+      const xliff = `<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="fr">
+  <file id="my-project">
+    <unit id="1">
+      <segment>
+        <source>home.title</source>
+        <target>Accueil</target>
+      </segment>
+    </unit>
+    <unit id="2">
+      <segment>
+        <source>home.subtitle</source>
+        <target>Bienvenue</target>
+      </segment>
+    </unit>
+  </file>
+</xliff>`;
+
+      const result = format.parseImport(xliff);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        "home.title": "Accueil",
+        "home.subtitle": "Bienvenue",
+      });
+    });
   });
 
   describe("exportSingleLocale", () => {

--- a/apps/website/app/lib/format/xliff-format.server.ts
+++ b/apps/website/app/lib/format/xliff-format.server.ts
@@ -54,8 +54,26 @@ export class XliffTranslationFormat implements TranslationFormat {
       while ((unitMatch = unitRegex.exec(fileContent)) !== null) {
         const attrsStr = unitMatch[1];
         const unitContent = unitMatch[2];
-        const keyName =
-          extractAttr(attrsStr, "name") ?? extractAttr(attrsStr, "id") ?? "";
+
+        let keyName = extractAttr(attrsStr, "name");
+
+        // if not key "name", take the "<source>" content
+        // Mainly because Symfony does not add "name" for sources that are more that 80 characters long
+        // https://github.com/symfony/symfony/pull/26661
+        if (!keyName) {
+          const sourceMatch = /<source>([\s\S]*?)<\/source>/.exec(unitContent);
+          if (sourceMatch) {
+            keyName = unescapeXml(sourceMatch[1]);
+          }
+        }
+
+        if (!keyName) {
+          return {
+            success: false,
+            error:
+              'No key name found for a <unit> (missing "name" attribute and <source> tag)',
+          };
+        }
 
         const targetMatch = /<target>([\s\S]*?)<\/target>/.exec(unitContent);
 


### PR DESCRIPTION
See https://github.com/symfony/symfony/pull/26661

Symfony does not include "name" attribute is source translation is more that 80 characters. 
In that case, we do not want to take the "id", but the source element instead.