### PR TITLE
[cli] handle 404 responses without returning an error code

### DIFF
--- a/.changeset/cli-handle-404-no-translations.md
+++ b/.changeset/cli-handle-404-no-translations.md
@@ -1,0 +1,5 @@
+---
+"@transi-store/cli": patch
+---
+
+Handle 404 responses when a locale has no translations without returning an error code

--- a/packages/cli/src/fetchForConfig.ts
+++ b/packages/cli/src/fetchForConfig.ts
@@ -82,6 +82,10 @@ async function fetchTranslationsAndPrint(
     console.log(
       `${styleText("green", "✓")} ${styleText("bold", name)} ${styleText("dim", "→")} ${result.output}`,
     );
+  } else if ("skipped" in result) {
+    console.log(
+      `${styleText("dim", "-")} ${styleText("bold", name)} — ${styleText("dim", "no translations")}`,
+    );
   } else {
     console.error(
       `${styleText("red", "✗")} ${styleText("bold", name)} — ${styleText("red", result.error)}`,
@@ -255,6 +259,10 @@ export async function fetchForConfig(
             console.log(
               `  ${counter} ${styleText("green", "✓")} ${styleText("bold", label)}`,
             );
+          } else if ("skipped" in fetchResult) {
+            console.log(
+              `  ${counter} ${styleText("dim", "-")} ${styleText("bold", label)}`,
+            );
           } else {
             console.log(
               `  ${counter} ${styleText("red", "✗")} ${styleText("bold", label)} — ${styleText("red", fetchResult.error)}`,
@@ -270,6 +278,7 @@ export async function fetchForConfig(
   }
 
   const failures: Array<{ label: string; error: string }> = [];
+  let skippedCount = 0;
 
   for (const project of projectOrder) {
     const fileResults = resultsMap.get(project)!;
@@ -284,6 +293,9 @@ export async function fetchForConfig(
         if (!res) continue;
         if (res.success) {
           statuses.push(styleText("green", `✓ ${locale}`));
+        } else if ("skipped" in res) {
+          statuses.push(styleText("dim", `- ${locale}`));
+          skippedCount++;
         } else {
           statuses.push(styleText("red", `✗ ${locale}`));
           failures.push({
@@ -300,20 +312,45 @@ export async function fetchForConfig(
 
   console.log();
 
-  const succeeded = total - failures.length;
+  const succeeded = total - failures.length - skippedCount;
   if (failures.length === 0) {
-    console.log(
-      styleText(
-        ["green", "bold"],
-        `✓ All ${total} translation${total > 1 ? "s" : ""} downloaded successfully`,
-      ),
-    );
+    if (skippedCount === 0) {
+      console.log(
+        styleText(
+          ["green", "bold"],
+          `✓ All ${total} translation${total > 1 ? "s" : ""} downloaded successfully`,
+        ),
+      );
+    } else {
+      if (succeeded > 0) {
+        console.log(
+          styleText(
+            "green",
+            `✓ ${succeeded} translation${succeeded > 1 ? "s" : ""} downloaded`,
+          ),
+        );
+      }
+      console.log(
+        styleText(
+          "dim",
+          `- ${skippedCount} locale${skippedCount > 1 ? "s" : ""} skipped (no translations)`,
+        ),
+      );
+    }
   } else {
     if (succeeded > 0) {
       console.log(
         styleText(
           "green",
           `✓ ${succeeded} translation${succeeded > 1 ? "s" : ""} downloaded`,
+        ),
+      );
+    }
+    if (skippedCount > 0) {
+      console.log(
+        styleText(
+          "dim",
+          `- ${skippedCount} locale${skippedCount > 1 ? "s" : ""} skipped (no translations)`,
         ),
       );
     }

--- a/packages/cli/src/fetchForConfig.ts
+++ b/packages/cli/src/fetchForConfig.ts
@@ -78,13 +78,13 @@ async function fetchTranslationsAndPrint(
     ? `${label.project} / ${label.fileName} / ${label.locale}`
     : `${config.project} / ${config.locale}`;
 
-  if (result.success) {
-    console.log(
-      `${styleText("green", "✓")} ${styleText("bold", name)} ${styleText("dim", "→")} ${result.output}`,
-    );
-  } else if ("skipped" in result) {
+  if ("skipped" in result) {
     console.log(
       `${styleText("dim", "-")} ${styleText("bold", name)} — ${styleText("dim", "no translations")}`,
+    );
+  } else if (result.success) {
+    console.log(
+      `${styleText("green", "✓")} ${styleText("bold", name)} ${styleText("dim", "→")} ${result.output}`,
     );
   } else {
     console.error(
@@ -255,13 +255,13 @@ export async function fetchForConfig(
           const counter = styleText("dim", `[${completed}/${total}]`);
           const label = `${task.project} / ${task.fileName} / ${task.locale}`;
 
-          if (fetchResult.success) {
-            console.log(
-              `  ${counter} ${styleText("green", "✓")} ${styleText("bold", label)}`,
-            );
-          } else if ("skipped" in fetchResult) {
+          if ("skipped" in fetchResult) {
             console.log(
               `  ${counter} ${styleText("dim", "-")} ${styleText("bold", label)}`,
+            );
+          } else if (fetchResult.success) {
+            console.log(
+              `  ${counter} ${styleText("green", "✓")} ${styleText("bold", label)}`,
             );
           } else {
             console.log(
@@ -291,11 +291,11 @@ export async function fetchForConfig(
       for (const locale of locales) {
         const res = localeResults.get(locale);
         if (!res) continue;
-        if (res.success) {
-          statuses.push(styleText("green", `✓ ${locale}`));
-        } else if ("skipped" in res) {
+        if ("skipped" in res) {
           statuses.push(styleText("dim", `- ${locale}`));
           skippedCount++;
+        } else if (res.success) {
+          statuses.push(styleText("green", `✓ ${locale}`));
         } else {
           statuses.push(styleText("red", `✗ ${locale}`));
           failures.push({

--- a/packages/cli/src/fetchTranslations.ts
+++ b/packages/cli/src/fetchTranslations.ts
@@ -18,7 +18,8 @@ export type Config = {
 
 export type FetchResult =
   | { success: true; output: string }
-  | { success: false; error: string; output: string };
+  | { success: false; error: string; output: string }
+  | { skipped: true; output: string };
 
 export async function fetchTranslations({
   domainRoot,
@@ -50,6 +51,10 @@ export async function fetchTranslations({
       error: `${describeFetchError(error)} (${url})`,
       output,
     };
+  }
+
+  if (content.status === 404) {
+    return { skipped: true, output };
   }
 
   if (!content.ok) {


### PR DESCRIPTION
When a locale has no translations, the API now returns 404 (since #162).
Treat this as a non-fatal skipped state rather than an error so the CLI
exits with code 0. Skipped locales are shown with `-` in output and
counted separately in the final summary.

https://claude.ai/code/session_01WTGFTMEgEiHUrybeCKYFmS