### PR TITLE
Fix markdown / MDX handling in file-scoped translations API

### DIFF
--- a/.agents/instructions/api.instructions.md
+++ b/.agents/instructions/api.instructions.md
@@ -14,3 +14,5 @@ When adding or changing an endpoint:
 3. Register the endpoint in `apps/website/app/lib/api-doc/openapi.server.ts`.
 
 Prefer reusing the existing import/export and format services instead of duplicating request parsing or translation-format logic inside route handlers.
+
+Every endpoint change must come with tests. Add cases for the success path, the new error branches (400/404/etc.), and any cross-cutting rules such as auth or organization scoping. Loader/action tests live next to the route file (e.g. `*.translations.export.test.ts`); helper functions get their own `*.server.test.ts` next to the implementation.

--- a/.agents/instructions/repository.instructions.md
+++ b/.agents/instructions/repository.instructions.md
@@ -14,4 +14,5 @@ This file is the generic repository-wide instruction source. Tool-specific entry
 - All protected operations are multi-tenant and must scope work to the current organization.
 - When changing an API endpoint, keep shared Zod schemas and OpenAPI registration in sync.
 - When changing a user-visible feature, update the MDX docs in `apps/website/app/docs/` when needed.
+- Always add or update tests when you change behavior: cover new code paths, error branches, and bug fixes. A change is not complete until it has tests, and the existing test suite (`make test`) still passes.
 - If a task brief exists in `specs/`, use it as execution context, not as the source of truth for repository rules.

--- a/.changeset/chatty-eagles-agree.md
+++ b/.changeset/chatty-eagles-agree.md
@@ -1,0 +1,5 @@
+---
+"@transi-store/cli": minor
+---
+
+Allow downloading of .md and .mdx files

--- a/apps/website/app/lib/api-doc/openapi.server.ts
+++ b/apps/website/app/lib/api-doc/openapi.server.ts
@@ -4,6 +4,7 @@ import {
 } from "@asteasolutions/zod-to-openapi";
 import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
+import { KEYVALUE_FORMATS, SupportedFormat } from "@transi-store/common";
 import { exportQuerySchema, exportErrorResponseSchema } from "./schemas/export";
 import {
   importFieldsSchema,
@@ -131,6 +132,7 @@ export async function generateOpenApiDocument(user?: SessionData | null) {
     description:
       "Download translations for a single locale, scoped to one project file. " +
       "The file's stored format is used by default; pass `format` to override. " +
+      "For a document file (MDX, Markdown), it must match the file's stored format exactly. " +
       "The response is returned as a file attachment.",
     tags: ["Translations"],
     security: [{ BearerApiKey: [] }],
@@ -140,7 +142,20 @@ export async function generateOpenApiDocument(user?: SessionData | null) {
         projectSlug: projectSlugParam,
         fileId: fileIdParam,
       }),
-      query: exportQuerySchema(localeExample).partial({ format: true }),
+      query: exportQuerySchema(localeExample)
+        .partial({ format: true })
+        .extend({
+          format: z
+            .enum(KEYVALUE_FORMATS as Array<SupportedFormat>)
+            .optional()
+            .openapi({
+              description:
+                "Output format. Defaults to the file's stored format. " +
+                "Omit to use the file's format automatically. " +
+                "Markdown and MDX files are returned in their native format and do not accept any format override.",
+              example: SupportedFormat.JSON,
+            }),
+        }),
     },
     responses: {
       200: {

--- a/apps/website/app/lib/markdown-documents.server.test.ts
+++ b/apps/website/app/lib/markdown-documents.server.test.ts
@@ -15,6 +15,7 @@ import {
   setSectionFuzzy,
   recordAiTranslation,
   getProjectFileTranslations,
+  getDocumentTranslation,
   getSectionStatesForTranslations,
   MarkdownDocumentConflictError,
   MarkdownTranslationMissingError,
@@ -374,6 +375,57 @@ describe("markdown-documents.server", () => {
       });
       expect(state.isFuzzy).toBe(false);
       expect(state.lastAiTranslatedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("getDocumentTranslation", () => {
+    it("returns undefined when no row exists for the (file, locale)", async () => {
+      const result = await getDocumentTranslation(projectFileId, "en");
+      expect(result).toBeUndefined();
+    });
+
+    it("returns the saved row for the requested locale", async () => {
+      await saveDocumentTranslation({
+        projectFileId,
+        locale: "en",
+        content: SOURCE_DOC,
+        format: SupportedFormat.MARKDOWN,
+      });
+
+      const result = await getDocumentTranslation(projectFileId, "en");
+      expect(result).toBeDefined();
+      expect(result?.locale).toBe("en");
+      expect(result?.content).toBe(SOURCE_DOC);
+    });
+
+    it("does not return rows from other locales", async () => {
+      await saveDocumentTranslation({
+        projectFileId,
+        locale: "en",
+        content: SOURCE_DOC,
+        format: SupportedFormat.MARKDOWN,
+      });
+
+      const result = await getDocumentTranslation(projectFileId, "fr");
+      expect(result).toBeUndefined();
+    });
+
+    it("does not return rows from other project files", async () => {
+      await saveDocumentTranslation({
+        projectFileId,
+        locale: "en",
+        content: SOURCE_DOC,
+        format: SupportedFormat.MARKDOWN,
+      });
+
+      const otherFile = await createProjectFile(db, {
+        projectId: 1,
+        format: SupportedFormat.MARKDOWN,
+        filePath: "docs/<lang>/other.md",
+      });
+
+      const result = await getDocumentTranslation(otherFile.id, "en");
+      expect(result).toBeUndefined();
     });
   });
 

--- a/apps/website/app/lib/markdown-documents.server.ts
+++ b/apps/website/app/lib/markdown-documents.server.ts
@@ -36,6 +36,21 @@ export async function getProjectFileTranslations(
 }
 
 /**
+ * Fetch the document body for a single (projectFile, locale). Returns
+ * `undefined` when no translation has been saved yet for this locale.
+ * Callers are responsible for verifying that the project file belongs to
+ * the authenticated organization.
+ */
+export async function getDocumentTranslation(
+  projectFileId: number,
+  locale: string,
+): Promise<MarkdownDocumentTranslation | undefined> {
+  return await db.query.markdownDocumentTranslations.findFirst({
+    where: { projectFileId, locale },
+  });
+}
+
+/**
  * Bulk-fetch the section states for a list of translation rows. Returns an
  * empty array when the list is empty.
  */

--- a/apps/website/app/routes/api.orgs.$orgSlug.projects.$projectSlug.files.$fileId.translations.export.test.ts
+++ b/apps/website/app/routes/api.orgs.$orgSlug.projects.$projectSlug.files.$fileId.translations.export.test.ts
@@ -227,6 +227,200 @@ describe("Export file-scoped loader", () => {
     },
   );
 
+  it("should still allow converting between key/value formats on a non-document file", async () => {
+    await createProjectLanguage(getTestDb(), 1);
+    await createTranslationKey(getTestDb(), 1, "test.key", {
+      fileId: projectFile.id,
+    });
+    await createTranslation(getTestDb(), 1, "en", "Test Value");
+
+    const response = await callLoader(
+      `https://example.com/api/orgs/test-org/projects/test-project/files/${projectFile.id}/translations?locale=en&format=yaml`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("yaml");
+  });
+
+  it("should return 400 when requesting markdown format on a non-document file", async () => {
+    await createProjectLanguage(getTestDb(), 1);
+
+    const response = await callLoader(
+      `https://example.com/api/orgs/test-org/projects/test-project/files/${projectFile.id}/translations?locale=en&format=markdown`,
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe(
+      "Format 'markdown' does not match the file's format 'json'. Omit the 'format' query param or set it to 'json'.",
+    );
+  });
+
+  it("should return 400 when requesting mdx format on a non-document file", async () => {
+    await createProjectLanguage(getTestDb(), 1);
+
+    const response = await callLoader(
+      `https://example.com/api/orgs/test-org/projects/test-project/files/${projectFile.id}/translations?locale=en&format=mdx`,
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe(
+      "Format 'mdx' does not match the file's format 'json'. Omit the 'format' query param or set it to 'json'.",
+    );
+  });
+
+  describe("markdown / mdx files", () => {
+    async function createMarkdownFile(
+      format: SupportedFormat,
+      filePath: string,
+    ): Promise<schema.ProjectFile> {
+      return await createProjectFile(getTestDb(), {
+        projectId: 1,
+        format,
+        filePath,
+      });
+    }
+
+    async function saveDocumentTranslation(
+      projectFileId: number,
+      locale: string,
+      content: string,
+    ): Promise<void> {
+      await getTestDb()
+        .insert(schema.markdownDocumentTranslations)
+        .values({ projectFileId, locale, content });
+    }
+
+    it("should return the markdown document body for the requested locale", async () => {
+      await createProjectLanguage(getTestDb(), 1);
+      const file = await createMarkdownFile(
+        SupportedFormat.MARKDOWN,
+        "docs/<lang>/intro.md",
+      );
+      await saveDocumentTranslation(file.id, "en", "# Hello\n\nWorld");
+
+      const response = await callLoader(
+        `https://example.com/api/orgs/test-org/projects/test-project/files/${file.id}/translations?locale=en`,
+        file.id,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toBe(
+        "text/markdown; charset=utf-8",
+      );
+      expect(response.headers.get("Content-Disposition")).toContain(".md");
+      expect(await response.text()).toBe("# Hello\n\nWorld");
+    });
+
+    it("should return the mdx document body for the requested locale", async () => {
+      await createProjectLanguage(getTestDb(), 1);
+      const file = await createMarkdownFile(
+        SupportedFormat.MDX,
+        "docs/<lang>/intro.mdx",
+      );
+      await saveDocumentTranslation(
+        file.id,
+        "en",
+        "# Hello\n\n<MyComponent />",
+      );
+
+      const response = await callLoader(
+        `https://example.com/api/orgs/test-org/projects/test-project/files/${file.id}/translations?locale=en`,
+        file.id,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toBe(
+        "text/mdx; charset=utf-8",
+      );
+      expect(response.headers.get("Content-Disposition")).toContain(".mdx");
+      expect(await response.text()).toBe("# Hello\n\n<MyComponent />");
+    });
+
+    it("should accept format=markdown when the file is a markdown file", async () => {
+      await createProjectLanguage(getTestDb(), 1);
+      const file = await createMarkdownFile(
+        SupportedFormat.MARKDOWN,
+        "docs/<lang>/intro.md",
+      );
+      await saveDocumentTranslation(file.id, "en", "# Hi");
+
+      const response = await callLoader(
+        `https://example.com/api/orgs/test-org/projects/test-project/files/${file.id}/translations?locale=en&format=markdown`,
+        file.id,
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("# Hi");
+    });
+
+    it("should return 400 when format=json is requested on a markdown file", async () => {
+      await createProjectLanguage(getTestDb(), 1);
+      const file = await createMarkdownFile(
+        SupportedFormat.MARKDOWN,
+        "docs/<lang>/intro.md",
+      );
+      await saveDocumentTranslation(file.id, "en", "# Hi");
+
+      const response = await callLoader(
+        `https://example.com/api/orgs/test-org/projects/test-project/files/${file.id}/translations?locale=en&format=json`,
+        file.id,
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toBe(
+        "Format 'json' does not match the file's format 'markdown'. Omit the 'format' query param or set it to 'markdown'.",
+      );
+    });
+
+    it("should return 400 when format=mdx is requested on a markdown file", async () => {
+      await createProjectLanguage(getTestDb(), 1);
+      const file = await createMarkdownFile(
+        SupportedFormat.MARKDOWN,
+        "docs/<lang>/intro.md",
+      );
+      await saveDocumentTranslation(file.id, "en", "# Hi");
+
+      const response = await callLoader(
+        `https://example.com/api/orgs/test-org/projects/test-project/files/${file.id}/translations?locale=en&format=mdx`,
+        file.id,
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toBe(
+        "Format 'mdx' does not match the file's format 'markdown'. Omit the 'format' query param or set it to 'markdown'.",
+      );
+    });
+
+    it("should return 404 when no translation row exists for the locale", async () => {
+      await createProjectLanguage(getTestDb(), 1, {
+        locale: "en",
+        isDefault: true,
+      });
+      await createProjectLanguage(getTestDb(), 1, {
+        locale: "es",
+        isDefault: false,
+      });
+      const file = await createMarkdownFile(
+        SupportedFormat.MARKDOWN,
+        "docs/<lang>/intro.md",
+      );
+      await saveDocumentTranslation(file.id, "en", "# Hi");
+
+      const response = await callLoader(
+        `https://example.com/api/orgs/test-org/projects/test-project/files/${file.id}/translations?locale=es`,
+        file.id,
+      );
+
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error).toBe("No translations found for locale 'es'");
+    });
+  });
+
   it("should use the DB file id and filePath in the XLIFF export", async () => {
     const db = getTestDb();
     await createProjectLanguage(db, 1);

--- a/apps/website/app/routes/api.orgs.$orgSlug.projects.$projectSlug.files.$fileId.translations.tsx
+++ b/apps/website/app/routes/api.orgs.$orgSlug.projects.$projectSlug.files.$fileId.translations.tsx
@@ -1,9 +1,14 @@
-import { ALL_BRANCHES_VALUE } from "@transi-store/common";
+import {
+  ALL_BRANCHES_VALUE,
+  isDocumentFormat,
+  SupportedFormat,
+} from "@transi-store/common";
 import { getProjectBySlug, getProjectLanguages } from "~/lib/projects.server";
 import { getProjectFileById } from "~/lib/project-files.server";
 import { getProjectTranslations } from "~/lib/translation-keys.server";
 import { getBranchBySlug } from "~/lib/branches.server";
 import { createTranslationFormat } from "~/lib/format/format-factory.server";
+import { getDocumentTranslation } from "~/lib/markdown-documents.server";
 import { orgContext } from "~/middleware/api-auth";
 import type { Route } from "./+types/api.orgs.$orgSlug.projects.$projectSlug.files.$fileId.translations";
 import { exportQuerySchema } from "~/lib/api-doc/schemas/export";
@@ -77,6 +82,17 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
     branch: branchParam,
   } = queryParseResult.data;
 
+  const fileIsDocument = isDocumentFormat(file.format);
+  const requestIsDocument = isDocumentFormat(formatName);
+  if (fileIsDocument || requestIsDocument) {
+    if (formatName !== file.format) {
+      return jsonError(
+        400,
+        `Format '${formatName}' does not match the file's format '${file.format}'. Omit the 'format' query param or set it to '${file.format}'.`,
+      );
+    }
+  }
+
   const languages = await getProjectLanguages(project.id);
   if (languages.length === 0) {
     return jsonError(400, i18next.t("import.errors.noLanguagesConfigured"));
@@ -88,6 +104,27 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
       400,
       i18next.t("import.errors.localeNotInProject", { locale }),
     );
+  }
+
+  if (isDocumentFormat(file.format)) {
+    const translation = await getDocumentTranslation(file.id, locale);
+    if (!translation) {
+      return jsonError(404, `No translations found for locale '${locale}'`);
+    }
+
+    const isMdx = file.format === SupportedFormat.MDX;
+    const fileExtension = isMdx ? "mdx" : "md";
+    const contentType = isMdx
+      ? "text/mdx; charset=utf-8"
+      : "text/markdown; charset=utf-8";
+    const filename = `${project.slug}-${file.id}-${locale}.${fileExtension}`;
+
+    return new Response(translation.content, {
+      headers: {
+        "Content-Type": contentType,
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
   }
 
   let branchId: number | undefined;
@@ -113,15 +150,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   );
 
   if (!hasTranslationsForLocale) {
-    return new Response(
-      JSON.stringify({
-        error: `No translations found for locale '${locale}'`,
-      }),
-      {
-        status: 404,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return jsonError(404, `No translations found for locale '${locale}'`);
   }
 
   const format = createTranslationFormat(formatName);

--- a/docs/technical-notes/export-api.md
+++ b/docs/technical-notes/export-api.md
@@ -2,9 +2,11 @@
 
 ## Overview
 
-The export API lets you download project translations in several formats: JSON, XLIFF 2.0, YAML, CSV, Gettext PO, INI, and PHP. It supports two authentication methods: user session or API key.
+The export API lets you download project translations in several formats: JSON, XLIFF 2.0, YAML, CSV, Gettext PO, INI, PHP, Markdown, and MDX. It supports two authentication methods: user session or API key.
 
 Translations are scoped to a single project file (see `project_files` table). The list of files for a project is available via `GET /api/orgs/:orgSlug/projects/:projectSlug`.
+
+Each project file has a stored format. Key/value formats (JSON, XLIFF, YAML, CSV, PO, INI, PHP) can be requested in any of those formats — the export is converted on the fly. Document formats (Markdown, MDX) are stored as a single document body per locale; the `format` query parameter, when provided, must equal the file's stored format. Mixing a key/value `format` with a document file (or vice versa) returns 400.
 
 ## Endpoint
 
@@ -50,11 +52,11 @@ Creating a key: via the web UI at `/orgs/:orgSlug/settings` (API Keys section). 
 
 ## Query parameters
 
-| Parameter | Values                               | Required | Description                                                 |
-| --------- | ------------------------------------ | -------- | ----------------------------------------------------------- |
-| `format`  | json, xliff, yaml, csv, po, ini, php | Yes      | Output format                                               |
-| `locale`  | string                               | Yes      | Language code (e.g. `fr`, `en`)                             |
-| `branch`  | string                               | No       | Branch slug (defaults to main). Use `@all` for all branches |
+| Parameter | Values                                              | Required | Description                                                                                                                                                            |
+| --------- | --------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `format`  | json, xliff, yaml, csv, po, ini, php, markdown, mdx | No       | Output format. Defaults to the file's stored format. For markdown/mdx files, must match the file's format exactly. Mixing key/value with document formats returns 400. |
+| `locale`  | string                                              | Yes      | Language code (e.g. `fr`, `en`)                                                                                                                                        |
+| `branch`  | string                                              | No       | Branch slug (defaults to main). Use `@all` for all branches                                                                                                            |
 
 ## JSON format
 
@@ -239,6 +241,28 @@ Notes:
 - On import, both single-quoted and double-quoted strings are supported
 - Single quotes in values are properly escaped with backslash
 
+## Markdown / MDX format
+
+**Example**:
+
+```bash
+GET /api/orgs/my-org/projects/app/files/1/translations?locale=fr
+```
+
+**Response** (raw markdown body for the requested locale):
+
+```markdown
+# Bienvenue
+
+Ceci est un document traduit.
+```
+
+Notes:
+
+- Markdown and MDX files store one document body per locale; the response is the raw body.
+- The `format` query parameter is optional. When set, it must equal the file's stored format (`markdown` or `mdx`); requesting `json`, `yaml`, etc. on a markdown/mdx file returns 400, and requesting `markdown`/`mdx` on a key/value file also returns 400.
+- A 404 is returned only when the locale is configured on the project but no document body has been saved yet for it.
+
 ## Response headers
 
 ### JSON
@@ -288,6 +312,20 @@ Content-Disposition: attachment; filename="project-slug-fr.ini"
 ```http
 Content-Type: text/x-php; charset=utf-8
 Content-Disposition: attachment; filename="project-slug-fr.php"
+```
+
+### Markdown
+
+```http
+Content-Type: text/markdown; charset=utf-8
+Content-Disposition: attachment; filename="project-slug-1-fr.md"
+```
+
+### MDX
+
+```http
+Content-Type: text/mdx; charset=utf-8
+Content-Disposition: attachment; filename="project-slug-1-fr.mdx"
 ```
 
 ## Error handling

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -4,6 +4,7 @@ export {
   FORMAT_LABELS,
   SUPPORTED_FORMATS_LIST,
   DOCUMENT_FORMATS,
+  KEYVALUE_FORMATS,
   getFormatFromFilename,
   isSupportedFormat,
   isDocumentFormat,

--- a/packages/common/src/supported-format.ts
+++ b/packages/common/src/supported-format.ts
@@ -36,6 +36,15 @@ export function isDocumentFormat(format: string): boolean {
   return (DOCUMENT_FORMATS as ReadonlyArray<string>).includes(format);
 }
 
+/**
+ * Formats stored as a key/value bag (one row per translation key, locale,
+ * and branch). These can be converted between each other on export, unlike
+ * document formats which are tied to the file's stored format.
+ */
+export const KEYVALUE_FORMATS = Object.values(SupportedFormat).filter(
+  (f) => !isDocumentFormat(f),
+) as ReadonlyArray<SupportedFormat>;
+
 /** Formatted list of supported formats for display in error messages: `'json', 'xliff', …` */
 export const SUPPORTED_FORMATS_LIST = new Intl.ListFormat("en", {
   type: "disjunction",


### PR DESCRIPTION
## Summary

Fix several issues with the file-scoped translations API (`GET /api/orgs/:orgSlug/projects/:projectSlug/files/:fileId/translations`) when the project file is a markdown / MDX document, and when callers mix document and key/value formats.

## Bugs fixed

- **500 → 400**: requesting `format=markdown` or `format=mdx` on a key/value file (json, xliff, yaml…) used to throw `DocumentFormatNotSupportedError` and bubble up as a 500. It now returns 400 with a clear message.
- **Document files returned 404 instead of content**: for markdown / MDX files, the route was looking for translation keys and 404'd with `No translations found for locale '…'`. It now returns the raw document body for the requested locale with `Content-Type: text/markdown` (or `text/mdx`) and a sensible `Content-Disposition` filename. 404 is reserved for the case where no document body has been saved yet for that locale.
- **OpenAPI listed markdown/mdx as selectable formats**: the `format` query parameter for the export endpoint no longer offers markdown / mdx in the OpenAPI schema. The description now explains that the format must match the file's stored format and that document files are returned natively.
- **Strict format match for documents**: passing a `format` query param that does not match the file's format returns 400 whenever either side is a document format (markdown / mdx). Conversion between key/value formats (e.g. `format=yaml` on a JSON file) keeps working as before. Omitting `format` still falls back to the file's stored format automatically.

## Other changes

- Add `KEYVALUE_FORMATS` to `@transi-store/common` and a `getDocumentTranslation(projectFileId, locale)` helper to `markdown-documents.server.ts`.
- Update `docs/technical-notes/export-api.md` with the new behavior (markdown / mdx section, response headers, query parameter table).
- Add an instruction in `.agents/instructions/repository.instructions.md` and `.agents/instructions/api.instructions.md` to always add or update tests when changing behavior.

## Tests

- 9 new cases in the route loader test file covering: 400 on format/file mismatch (markdown/mdx asked on a JSON file, json/mdx asked on a markdown file), key/value-to-key/value conversion still works, markdown body returned with the right Content-Type / extension, mdx body returned likewise, explicit `format=markdown` accepted on a markdown file, 404 only when no document body exists for the locale.
- 4 new cases for `getDocumentTranslation`: undefined when no row exists, returns the row for the requested locale, isolation between locales, isolation between project files.
- Total: 330 tests passing (`make test`).

## Test plan

- [x] `make lint-types`
- [x] `make test` (330 tests)
- [x] `make knip`
- [ ] Manual: hit `/api/orgs/.../files/<json-file-id>/translations?locale=en&format=markdown` → 400
- [ ] Manual: hit `/api/orgs/.../files/<md-file-id>/translations?locale=en` → markdown body with `Content-Type: text/markdown`
- [ ] Manual: open `/api/doc.json` and confirm the `format` enum no longer lists `markdown` / `mdx`
