### PR TITLE
Prepare merging translation branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         uses: ./.github/actions/setup-project
 
       - name: Run knip
-        run: yarn knip
+        run: yarn turbo knip
 
   i18next:
     name: i18next Validation

--- a/.github/workflows/merge-translations-branch.yml
+++ b/.github/workflows/merge-translations-branch.yml
@@ -1,0 +1,42 @@
+name: Merge translations branch
+
+# When a PR is merged into main, merge the matching transi-store branch into main.
+# Fork PRs: head.ref may not exist in transi-store; adjust with a same-repo guard if needed.
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Git branch slug matching the transi-store branch to merge"
+        required: true
+        type: string
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - run: corepack enable
+
+      - name: setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "yarn"
+
+      - run: yarn install
+
+      - name: Merge translation branch
+        env:
+          TRANSI_STORE_API_KEY: ${{ secrets.TRANSI_STORE_API_KEY }}
+        run: yarn turbo run merge-translations -- --branch "${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.event.pull_request.head.ref }}"

--- a/.github/workflows/merge-translations-branch.yml
+++ b/.github/workflows/merge-translations-branch.yml
@@ -26,17 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - run: corepack enable
-
-      - name: setup node
-        uses: actions/setup-node@v6
+      - uses: transi-store/merge-branch-action@v1
         with:
-          node-version: "24"
-          cache: "yarn"
-
-      - run: yarn install
-
-      - name: Merge translation branch
-        env:
-          TRANSI_STORE_API_KEY: ${{ secrets.TRANSI_STORE_API_KEY }}
-        run: yarn turbo run merge-translation-branch -- --branch "${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.event.pull_request.head.ref }}"
+          branch: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.event.pull_request.head.ref }}
+          api-key: ${{ secrets.TRANSI_STORE_API_KEY }}

--- a/.github/workflows/merge-translations-branch.yml
+++ b/.github/workflows/merge-translations-branch.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Merge translation branch
         env:
           TRANSI_STORE_API_KEY: ${{ secrets.TRANSI_STORE_API_KEY }}
-        run: yarn turbo run merge-translation-banch -- --branch "${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.event.pull_request.head.ref }}"
+        run: yarn turbo run merge-translation-branch -- --branch "${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.event.pull_request.head.ref }}"

--- a/.github/workflows/merge-translations-branch.yml
+++ b/.github/workflows/merge-translations-branch.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Merge translation branch
         env:
           TRANSI_STORE_API_KEY: ${{ secrets.TRANSI_STORE_API_KEY }}
-        run: yarn turbo run merge-translations -- --branch "${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.event.pull_request.head.ref }}"
+        run: yarn turbo run merge-translation-banch -- --branch "${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.event.pull_request.head.ref }}"

--- a/.github/workflows/merge-translations-branch.yml
+++ b/.github/workflows/merge-translations-branch.yml
@@ -16,7 +16,8 @@ on:
         type: string
 
 jobs:
-  merge:
+  merge-branch:
+    name: Merge transi-store branch
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
 

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Thumbs.db
 test-*.json
 
 .turbo
+
+# Local transi-store config for development
+transi-store.dev.config.json

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ lint-types: ## Check TypeScript types
 	docker compose exec app yarn lint:types
 
 knip: ## Analyze unused imports/exports
-	docker compose exec app yarn knip
+	docker compose exec app yarn turbo knip
 
 ## Database
 db-generate: ## Generate database migrations

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ start: ## Start the application in production
 	docker compose exec app yarn start
 
 test: ## Run tests
-	docker compose exec app yarn test --run
+	docker compose exec app yarn test -- --run
 
 lint: ## Check lint
 	docker compose exec app yarn turbo lint

--- a/apps/website/app/lib/api-doc/schemas/branch-merge.ts
+++ b/apps/website/app/lib/api-doc/schemas/branch-merge.ts
@@ -1,27 +1,34 @@
 import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
+import {
+  createBranchMergeErrorResponseSchema,
+  createBranchMergeSuccessResponseSchema,
+} from "@transi-store/common";
 
+// `.openapi()` is added to ZodType.prototype here, and schemas are instantiated
+// AFTER the patch so the method is available on them.
 extendZodWithOpenApi(z);
 
-export const branchMergeSuccessResponseSchema = z
-  .object({
-    success: z.literal(true),
-    keysMoved: z.number().int().openapi({
-      description: "Number of branch keys moved to the main branch.",
-      example: 5,
-    }),
-    keysDeleted: z.number().int().openapi({
-      description: "Number of main keys soft-deleted by the merge.",
-      example: 1,
-    }),
-  })
-  .openapi("BranchMergeSuccess");
+export const branchMergeSuccessResponseSchema =
+  createBranchMergeSuccessResponseSchema()
+    .extend({
+      keysMoved: z.number().int().openapi({
+        description: "Number of branch keys moved to the main branch.",
+        example: 5,
+      }),
+      keysDeleted: z.number().int().openapi({
+        description: "Number of main keys soft-deleted by the merge.",
+        example: 1,
+      }),
+    })
+    .openapi("BranchMergeSuccess");
 
-export const branchMergeErrorResponseSchema = z
-  .object({
-    error: z.string().openapi({
-      description: "Human-readable error message.",
-      example: 'Branch "feature-xyz" not found',
-    }),
-  })
-  .openapi("BranchMergeError");
+export const branchMergeErrorResponseSchema =
+  createBranchMergeErrorResponseSchema()
+    .extend({
+      error: z.string().openapi({
+        description: "Human-readable error message.",
+        example: 'Branch "feature-xyz" not found',
+      }),
+    })
+    .openapi("BranchMergeError");

--- a/apps/website/app/lib/api-doc/schemas/export.ts
+++ b/apps/website/app/lib/api-doc/schemas/export.ts
@@ -2,14 +2,18 @@ import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 import {
   ALL_BRANCHES_VALUE,
+  createExportErrorResponseSchema,
+  createExportQuerySchema,
   SupportedFormat,
   SUPPORTED_FORMATS_LIST,
 } from "@transi-store/common";
 
+// `.openapi()` is added to ZodType.prototype here, and schemas are instantiated
+// AFTER the patch so the method is available on them.
 extendZodWithOpenApi(z);
 
 export const exportQuerySchema = (localeExample = "fr") =>
-  z.object({
+  createExportQuerySchema().extend({
     format: z.enum(SupportedFormat).openapi({
       description: `Output format. Supported formats: ${SUPPORTED_FORMATS_LIST}.`,
       example: SupportedFormat.JSON,
@@ -28,8 +32,8 @@ export const exportQuerySchema = (localeExample = "fr") =>
       }),
   });
 
-export const exportErrorResponseSchema = z
-  .object({
+export const exportErrorResponseSchema = createExportErrorResponseSchema()
+  .extend({
     error: z.string().openapi({
       description: "Human-readable error message.",
       example: `Invalid format. Use ${SUPPORTED_FORMATS_LIST}`,

--- a/apps/website/app/lib/api-doc/schemas/import.ts
+++ b/apps/website/app/lib/api-doc/schemas/import.ts
@@ -1,15 +1,20 @@
 import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 import {
+  createImportErrorResponseSchema,
+  createImportFieldsSchema,
+  createImportSuccessResponseSchema,
   ImportStrategy,
   SupportedFormat,
   SUPPORTED_FORMATS_LIST,
 } from "@transi-store/common";
 
+// `.openapi()` is added to ZodType.prototype here, and schemas are instantiated
+// AFTER the patch so the method is available on them.
 extendZodWithOpenApi(z);
 
 export const importFieldsSchema = (localeExample = "fr") =>
-  z.object({
+  createImportFieldsSchema().extend({
     locale: z.string().openapi({
       description:
         "Language code to import into (must match one of the project's configured languages).",
@@ -34,38 +39,39 @@ export const importFieldsSchema = (localeExample = "fr") =>
     }),
   });
 
-export const importSuccessResponseSchema = z
-  .object({
-    success: z.literal(true),
-    stats: z.object({
-      total: z.number().openapi({
-        description: "Total number of entries processed from the file.",
-        example: 42,
-      }),
-      keysCreated: z.number().openapi({
-        description: "Number of new translation keys created.",
-        example: 5,
-      }),
-      translationsCreated: z.number().openapi({
-        description: "Number of new translations added.",
-        example: 8,
-      }),
-      translationsUpdated: z.number().openapi({
-        description:
-          "Number of existing translations updated (only with 'overwrite' strategy).",
-        example: 3,
-      }),
-      translationsSkipped: z.number().openapi({
-        description:
-          "Number of existing translations left untouched (only with 'skip' strategy).",
-        example: 0,
-      }),
-    }),
+export const importSuccessResponseSchema = createImportSuccessResponseSchema()
+  .extend({
+    stats: z
+      .object({
+        total: z.number().openapi({
+          description: "Total number of entries processed from the file.",
+          example: 42,
+        }),
+        keysCreated: z.number().openapi({
+          description: "Number of new translation keys created.",
+          example: 5,
+        }),
+        translationsCreated: z.number().openapi({
+          description: "Number of new translations added.",
+          example: 8,
+        }),
+        translationsUpdated: z.number().openapi({
+          description:
+            "Number of existing translations updated (only with 'overwrite' strategy).",
+          example: 3,
+        }),
+        translationsSkipped: z.number().openapi({
+          description:
+            "Number of existing translations left untouched (only with 'skip' strategy).",
+          example: 0,
+        }),
+      })
+      .openapi("ImportStats"),
   })
   .openapi("ImportSuccess");
 
-export const importErrorResponseSchema = z
-  .object({
+export const importErrorResponseSchema = createImportErrorResponseSchema()
+  .extend({
     error: z.string().openapi({
       description: "Human-readable error message.",
       example: "Missing 'locale' field",

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "clean": "node -e \"require('node:fs').rmSync('build', { recursive: true, force: true })\"",
+    "react-router-typegen": "react-router typegen",
     "dev": "react-router dev",
     "build": "yarn workspace @transi-store/common build && react-router build",
     "start": "react-router-serve ./build/server/index.js",

--- a/docs/technical-notes/branch-merge-api.md
+++ b/docs/technical-notes/branch-merge-api.md
@@ -26,7 +26,7 @@ The route **does not** look up the calling user. `mergeBranch()` is called with 
 | `404` | `BranchMergeError`                                                 | Project or branch not found.                              |
 | `405` | `BranchMergeError`                                                 | Request method is not `POST`.                             |
 
-Merging never produces a key conflict by construction: the unique index `unique_project_file_key` on `(project_id, file_id, key_name)` prevents a branch from ever holding a key that already exists on main. There is no `409` case.
+Merging never produces a key conflict by construction: the unique index `unique_project_file_key` on `(project_id, file_id, key_name)` prevents a branch from ever holding a key that already exists on main.
 
 ## Discriminated result in `mergeBranch`
 
@@ -34,7 +34,7 @@ Merging never produces a key conflict by construction: the unique index `unique_
 
 ## CLI
 
-The `transi-store branch:merge` command (in `@transi-store/cli`) wraps this endpoint. `--branch` is required: there is no git auto-detection, since the merge is destructive and the target must be explicit.
+The `transi-store merge` command (in `@transi-store/cli`) wraps this endpoint. `--branch` is required: there is no git auto-detection, since the merge is destructive and the target must be explicit.
 
 ## OpenAPI
 

--- a/docs/technical-notes/branch-merge-api.md
+++ b/docs/technical-notes/branch-merge-api.md
@@ -25,17 +25,16 @@ The route **does not** look up the calling user. `mergeBranch()` is called with 
 | `403` | `BranchMergeError`                                                 | API key does not belong to the requested organization.    |
 | `404` | `BranchMergeError`                                                 | Project or branch not found.                              |
 | `405` | `BranchMergeError`                                                 | Request method is not `POST`.                             |
-| `409` | `BranchMergeConflict` (`{ error, conflictingKeys[] }`)             | Some branch keys collide with existing main keys.         |
 
-`409` is reserved strictly for the unique-constraint conflict case, so clients can rely on the presence of `conflictingKeys` whenever they receive that status.
+Merging never produces a key conflict by construction: the unique index `unique_project_file_key` on `(project_id, file_id, key_name)` prevents a branch from ever holding a key that already exists on main. There is no `409` case.
 
 ## Discriminated result in `mergeBranch`
 
-`MergeBranchResult` carries a `reason` field on failure (`"not_found" | "not_open" | "conflict"`). The API route maps `reason` to a status code without string-matching on `error`. The UI keeps reading `error` and `conflictingKeys` as before.
+`MergeBranchResult` carries a `reason` field on failure (`"not_found" | "not_open"`). The API route maps `reason` to a status code without string-matching on `error`.
 
 ## CLI
 
-The `transi-store branch:merge` command (in `@transi-store/cli`) wraps this endpoint. `--branch` is required: there is no git auto-detection, since the merge is destructive and the target must be explicit. On `409` the CLI prints every conflicting key on its own line and exits `1`.
+The `transi-store branch:merge` command (in `@transi-store/cli`) wraps this endpoint. `--branch` is required: there is no git auto-detection, since the merge is destructive and the target must be explicit.
 
 ## OpenAPI
 

--- a/docs/technical-notes/branch-merge-api.md
+++ b/docs/technical-notes/branch-merge-api.md
@@ -17,15 +17,15 @@ The route **does not** look up the calling user. `mergeBranch()` is called with 
 
 ## Status codes
 
-| Code | Body schema | When |
-|------|-------------|------|
-| `200` | `BranchMergeSuccess` (`{ success: true, keysMoved, keysDeleted }`) | Merge succeeded. |
-| `400` | `BranchMergeError` (`{ error }`) | Branch exists but is not open (already merged or closed). |
-| `401` | `BranchMergeError` | Missing or invalid API key, no session. |
-| `403` | `BranchMergeError` | API key does not belong to the requested organization. |
-| `404` | `BranchMergeError` | Project or branch not found. |
-| `405` | `BranchMergeError` | Request method is not `POST`. |
-| `409` | `BranchMergeConflict` (`{ error, conflictingKeys[] }`) | Some branch keys collide with existing main keys. |
+| Code  | Body schema                                                        | When                                                      |
+| ----- | ------------------------------------------------------------------ | --------------------------------------------------------- |
+| `200` | `BranchMergeSuccess` (`{ success: true, keysMoved, keysDeleted }`) | Merge succeeded.                                          |
+| `400` | `BranchMergeError` (`{ error }`)                                   | Branch exists but is not open (already merged or closed). |
+| `401` | `BranchMergeError`                                                 | Missing or invalid API key, no session.                   |
+| `403` | `BranchMergeError`                                                 | API key does not belong to the requested organization.    |
+| `404` | `BranchMergeError`                                                 | Project or branch not found.                              |
+| `405` | `BranchMergeError`                                                 | Request method is not `POST`.                             |
+| `409` | `BranchMergeConflict` (`{ error, conflictingKeys[] }`)             | Some branch keys collide with existing main keys.         |
 
 `409` is reserved strictly for the unique-constraint conflict case, so clients can rely on the presence of `conflictingKeys` whenever they receive that status.
 
@@ -39,4 +39,4 @@ The `transi-store branch:merge` command (in `@transi-store/cli`) wraps this endp
 
 ## OpenAPI
 
-Schemas live in `apps/website/app/lib/api-doc/schemas/branch-merge.ts` and are registered in `apps/website/app/lib/api-doc/openapi.server.ts` alongside the existing translation endpoints.
+The response schemas are declared as factories in `packages/common/src/branch-merge-schema.ts` (`createBranchMergeSuccessResponseSchema`, `createBranchMergeErrorResponseSchema`) and reused on both sides: `apps/website/app/lib/api-doc/schemas/branch-merge.ts` enriches them with `.openapi()` metadata for the registry, and `@transi-store/cli` validates the API response with the same factory. See [openapi-documentation.md](./openapi-documentation.md#shared-schemas-always-use-packagescommon) for the rule and pattern.

--- a/docs/technical-notes/openapi-documentation.md
+++ b/docs/technical-notes/openapi-documentation.md
@@ -4,11 +4,11 @@ REST API documentation is automatically generated from **shared Zod schemas** vi
 
 ## Public URLs
 
-| URL               | Description                                              |
-| ----------------- | -------------------------------------------------------- |
-| `/api/doc`        | HTML page with Scalar rendering + site header            |
-| `/api/doc/viewer` | Standalone HTML page with Scalar CDN (iframe target)     |
-| `/api/doc.json`   | OpenAPI 3.1 specification (raw JSON)                     |
+| URL               | Description                                          |
+| ----------------- | ---------------------------------------------------- |
+| `/api/doc`        | HTML page with Scalar rendering + site header        |
+| `/api/doc/viewer` | Standalone HTML page with Scalar CDN (iframe target) |
+| `/api/doc.json`   | OpenAPI 3.1 specification (raw JSON)                 |
 
 These routes are public (no authentication required).
 
@@ -36,6 +36,68 @@ Zod schemas in `apps/website/app/lib/api-doc/schemas/` are the **single source o
 
 This approach guarantees that documentation is always synchronized with validation code.
 
+## Shared Schemas (ALWAYS use `packages/common`)
+
+API request and response schemas **MUST** live in `packages/common` and be reused by every consumer (API handlers, OpenAPI registry, `@transi-store/cli`, future SDKs). Never declare a duplicate local TypeScript type or Zod schema in a consumer — drift between the API and its clients is the failure mode this rule exists to prevent.
+
+### The factory pattern
+
+Schemas in `packages/common` are exposed as **factory functions** (`createFooSchema()`), not pre-built instances. This is required because `extendZodWithOpenApi(z)` patches `ZodType.prototype` and only affects schemas instantiated **after** the patch runs. If `common` exported a pre-built schema, the API side could not add `.openapi()` metadata to it.
+
+```typescript
+// packages/common/src/foo-schema.ts
+import z from "zod";
+
+export function createFooResponseSchema() {
+  return z.object({
+    success: z.literal(true),
+    count: z.number().int().describe("Number of items processed."),
+  });
+}
+
+export type FooResponse = z.infer<ReturnType<typeof createFooResponseSchema>>;
+```
+
+### The API side enriches with `.openapi()`
+
+```typescript
+// apps/website/app/lib/api-doc/schemas/foo.ts
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+import { createFooResponseSchema } from "@transi-store/common";
+
+extendZodWithOpenApi(z);
+
+export const fooResponseSchema = createFooResponseSchema()
+  .extend({
+    count: z.number().int().openapi({
+      description: "Number of items processed.",
+      example: 42,
+    }),
+  })
+  .openapi("FooResponse");
+```
+
+### Consumers (CLI, SDKs) validate with `safeParse()`
+
+Consumers import the **plain** factory from `@transi-store/common` (not the OpenAPI-enriched version) and validate API responses at runtime. No more local TS casts, no defensive `?? 0` fallbacks for fields the contract says are required.
+
+```typescript
+import { createFooResponseSchema } from "@transi-store/common";
+
+const fooResponseSchema = createFooResponseSchema();
+const parsed = fooResponseSchema.safeParse(await response.json());
+if (!parsed.success) {
+  return { ok: false, error: `Unexpected response: ${parsed.error.message}` };
+}
+```
+
+### Existing shared schemas (examples to follow)
+
+- `createProjectFileSchema`, `createProjectLanguageSchema`, `createProjectDetailSchema` — project detail endpoint
+- `createBranchMergeSuccessResponseSchema`, `createBranchMergeErrorResponseSchema` — branch merge endpoint
+- `configSchema` — CLI config file (used by CLI + JSON Schema generator)
+
 ### Handlers Using Schemas
 
 - **Export** (`apps/website/app/routes/api.orgs.$orgSlug.projects.$projectSlug.export.tsx`): Uses `exportQuerySchema.safeParse()` to validate query params.
@@ -45,10 +107,12 @@ This approach guarantees that documentation is always synchronized with validati
 
 When adding or modifying a documented API endpoint:
 
-1. **Update the Zod schema** in `apps/website/app/lib/api-doc/schemas/` (add fields, change types, etc.)
-2. **Use the schema in the handler** for validation (`safeParse()`)
-3. **Register the path in the OpenAPI registry** in `apps/website/app/lib/api-doc/openapi.server.ts`
-4. **Verify the rendering** on `/api/doc` after modification
+1. **Declare the schema factory in `packages/common/src/`** and export it from `packages/common/src/index.ts`.
+2. **Build the OpenAPI-enriched schema** in `apps/website/app/lib/api-doc/schemas/` by calling the factory and adding `.openapi()` metadata.
+3. **Use the schema in the handler** for validation (`safeParse()`).
+4. **Register the path in the OpenAPI registry** in `apps/website/app/lib/api-doc/openapi.server.ts`.
+5. **Reuse the common factory in every external consumer** (CLI, SDKs) to validate responses — never re-declare the shape.
+6. **Verify the rendering** on `/api/doc` after modification.
 
 ### Example: Adding a Query Parameter to Export
 
@@ -79,4 +143,3 @@ The color mode (light/dark) is passed as a `?theme=` query parameter from the pa
 
 - `@asteasolutions/zod-to-openapi`: Spec generation from Zod
 - No npm dependency for Scalar itself: loaded via CDN
-

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "start": "yarn workspace @transi-store/website start",
     "download-translations": "NODE_OPTIONS='--require dotenv/config' yarn transi-store",
     "upload-translations": "NODE_OPTIONS='--require dotenv/config' yarn transi-store upload:config",
+    "merge-translations": "NODE_OPTIONS='--require dotenv/config' yarn transi-store merge:config",
     "lint:eslint": "eslint .",
     "lint:types": "yarn turbo lint:types",
     "knip": "yarn workspace @transi-store/website react-router typegen && knip",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "yarn workspace @transi-store/website start",
     "download-translations": "NODE_OPTIONS='--require dotenv/config' yarn transi-store",
     "upload-translations": "NODE_OPTIONS='--require dotenv/config' yarn transi-store upload:config",
-    "merge-translations": "NODE_OPTIONS='--require dotenv/config' yarn transi-store merge:config",
+    "merge-translation-branch": "NODE_OPTIONS='--require dotenv/config' yarn transi-store merge",
     "lint:eslint": "eslint .",
     "lint:types": "yarn turbo lint:types",
     "knip": "yarn workspace @transi-store/website react-router typegen && knip",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "merge-translation-branch": "NODE_OPTIONS='--require dotenv/config' yarn transi-store merge",
     "lint:eslint": "eslint .",
     "lint:types": "yarn turbo lint:types",
-    "knip": "yarn workspace @transi-store/website react-router typegen && knip",
+    "knip": "knip",
     "db:generate": "yarn workspace @transi-store/website db:generate",
     "db:push": "yarn workspace @transi-store/website db:push --verbose",
     "db:studio": "yarn workspace @transi-store/website db:studio",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "db:push": "yarn workspace @transi-store/website db:push --verbose",
     "db:studio": "yarn workspace @transi-store/website db:studio",
     "db:setup-search": "./scripts/enable-fuzzy-search.sh",
-    "test": "yarn workspace @transi-store/website test",
+    "test": "yarn turbo test",
     "release": "yarn build:cli && yarn changeset publish",
     "postinstall": "[ \"$NODE_ENV\" = \"production\" ] || husky"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,13 +24,15 @@
   "devDependencies": {
     "@transi-store/common": "workspace:^",
     "rolldown": "^1.0.0-rc.12",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^4.0.18"
   },
   "scripts": {
     "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
     "build": "rolldown -c && tsc --emitDeclarationOnly && yarn build:schema",
     "build:schema": "node ./scripts/create-json-schema.mjs",
-    "lint:types": "tsc --noEmit"
+    "lint:types": "tsc --noEmit",
+    "test": "vitest"
   },
   "files": [
     "dist"

--- a/packages/cli/src/branchMerge.test.ts
+++ b/packages/cli/src/branchMerge.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildMergeBranchUrl, mergeBranch } from "./branchMerge.ts";
+
+describe("buildMergeBranchUrl", () => {
+  it("URL-encodes org, project and branch slugs", () => {
+    expect(
+      buildMergeBranchUrl({
+        domainRoot: "https://transi-store.com",
+        org: "my org",
+        project: "my project",
+        branch: "feature/branch",
+      }),
+    ).toBe(
+      "https://transi-store.com/api/orgs/my%20org/projects/my%20project/branches/feature%2Fbranch/merge",
+    );
+  });
+});
+
+describe("mergeBranch", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      ...init,
+    });
+  }
+
+  it("POSTs to the merge endpoint with the bearer token", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ keysMoved: 3, keysDeleted: 1 }),
+    );
+
+    const result = await mergeBranch({
+      domainRoot: "https://transi-store.com",
+      apiKey: "secret",
+      org: "acme",
+      project: "website",
+      branch: "feature-1",
+    });
+
+    expect(result).toEqual({ ok: true, keysMoved: 3, keysDeleted: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(
+      "https://transi-store.com/api/orgs/acme/projects/website/branches/feature-1/merge",
+    );
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: { Authorization: "Bearer secret" },
+    });
+  });
+
+  it("defaults missing counters to 0", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}));
+
+    const result = await mergeBranch({
+      domainRoot: "https://transi-store.com",
+      apiKey: "secret",
+      org: "acme",
+      project: "website",
+      branch: "feature-1",
+    });
+
+    expect(result).toEqual({ ok: true, keysMoved: 0, keysDeleted: 0 });
+  });
+
+  it("returns the API error message when the response is not ok", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        { error: 'Branch "feature-1" not found' },
+        { status: 404, statusText: "Not Found" },
+      ),
+    );
+
+    const result = await mergeBranch({
+      domainRoot: "https://transi-store.com",
+      apiKey: "secret",
+      org: "acme",
+      project: "website",
+      branch: "feature-1",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error:
+        'Failed to merge branch (404 Not Found): Branch "feature-1" not found',
+    });
+  });
+
+  it("falls back to statusText when the body is not JSON", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("nope", {
+        status: 500,
+        statusText: "Internal Server Error",
+      }),
+    );
+
+    const result = await mergeBranch({
+      domainRoot: "https://transi-store.com",
+      apiKey: "secret",
+      org: "acme",
+      project: "website",
+      branch: "feature-1",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error:
+        "Failed to merge branch (500 Internal Server Error): Internal Server Error",
+    });
+  });
+
+  it("returns a descriptive error when fetch itself throws", async () => {
+    fetchMock.mockRejectedValueOnce(
+      Object.assign(new TypeError("fetch failed"), {
+        cause: Object.assign(new Error("connect ECONNREFUSED"), {
+          code: "ECONNREFUSED",
+        }),
+      }),
+    );
+
+    const result = await mergeBranch({
+      domainRoot: "https://transi-store.com",
+      apiKey: "secret",
+      org: "acme",
+      project: "website",
+      branch: "feature-1",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Failed to merge branch at");
+      expect(result.error).toContain("ECONNREFUSED");
+    }
+  });
+});

--- a/packages/cli/src/branchMerge.test.ts
+++ b/packages/cli/src/branchMerge.test.ts
@@ -81,7 +81,7 @@ describe("mergeBranch", () => {
   it("returns the API error message when the response is not ok", async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse(
-        { error: 'Branch "feature-1" not found' },
+        { success: false, error: 'Branch "feature-1" not found' },
         { status: 404, statusText: "Not Found" },
       ),
     );

--- a/packages/cli/src/branchMerge.test.ts
+++ b/packages/cli/src/branchMerge.test.ts
@@ -38,7 +38,7 @@ describe("mergeBranch", () => {
 
   it("POSTs to the merge endpoint with the bearer token", async () => {
     fetchMock.mockResolvedValueOnce(
-      jsonResponse({ keysMoved: 3, keysDeleted: 1 }),
+      jsonResponse({ success: true, keysMoved: 3, keysDeleted: 1 }),
     );
 
     const result = await mergeBranch({
@@ -61,7 +61,7 @@ describe("mergeBranch", () => {
     });
   });
 
-  it("defaults missing counters to 0", async () => {
+  it("returns an error when the success response body is malformed", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({}));
 
     const result = await mergeBranch({
@@ -72,7 +72,10 @@ describe("mergeBranch", () => {
       branch: "feature-1",
     });
 
-    expect(result).toEqual({ ok: true, keysMoved: 0, keysDeleted: 0 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Unexpected response from merge endpoint");
+    }
   });
 
   it("returns the API error message when the response is not ok", async () => {

--- a/packages/cli/src/branchMerge.ts
+++ b/packages/cli/src/branchMerge.ts
@@ -1,4 +1,12 @@
+import {
+  createBranchMergeErrorResponseSchema,
+  createBranchMergeSuccessResponseSchema,
+} from "@transi-store/common";
 import { describeFetchError } from "./fetchProjectMetadata.ts";
+
+const branchMergeSuccessResponseSchema =
+  createBranchMergeSuccessResponseSchema();
+const branchMergeErrorResponseSchema = createBranchMergeErrorResponseSchema();
 
 export type MergeBranchOptions = {
   domainRoot: string;
@@ -18,12 +26,6 @@ export type MergeBranchResult =
       ok: false;
       error: string;
     };
-
-type MergeApiResponse = {
-  keysMoved?: number;
-  keysDeleted?: number;
-  error?: string;
-};
 
 export function buildMergeBranchUrl({
   domainRoot,
@@ -61,22 +63,32 @@ export async function mergeBranch({
     };
   }
 
-  let data: MergeApiResponse | null = null;
+  let rawBody: unknown = null;
   try {
-    data = (await response.json()) as MergeApiResponse;
+    rawBody = await response.json();
   } catch {
     // Empty or non-JSON body — fall back to statusText below.
   }
 
   if (response.ok) {
+    const parsed = branchMergeSuccessResponseSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: `Unexpected response from merge endpoint: ${parsed.error.message}`,
+      };
+    }
     return {
       ok: true,
-      keysMoved: data?.keysMoved ?? 0,
-      keysDeleted: data?.keysDeleted ?? 0,
+      keysMoved: parsed.data.keysMoved,
+      keysDeleted: parsed.data.keysDeleted,
     };
   }
 
-  const errorMessage = data?.error ?? response.statusText;
+  const parsedError = branchMergeErrorResponseSchema.safeParse(rawBody);
+  const errorMessage = parsedError.success
+    ? parsedError.data.error
+    : response.statusText;
   return {
     ok: false,
     error: `Failed to merge branch (${response.status} ${response.statusText}): ${errorMessage}`,

--- a/packages/cli/src/branchMerge.ts
+++ b/packages/cli/src/branchMerge.ts
@@ -1,6 +1,6 @@
 import { describeFetchError } from "./fetchProjectMetadata.ts";
 
-type MergeBranchOptions = {
+export type MergeBranchOptions = {
   domainRoot: string;
   apiKey: string;
   org: string;
@@ -8,14 +8,43 @@ type MergeBranchOptions = {
   branch: string;
 };
 
-export async function mergeBranchCommand({
+export type MergeBranchResult =
+  | {
+      ok: true;
+      keysMoved: number;
+      keysDeleted: number;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+type MergeApiResponse = {
+  keysMoved?: number;
+  keysDeleted?: number;
+  error?: string;
+};
+
+export function buildMergeBranchUrl({
+  domainRoot,
+  org,
+  project,
+  branch,
+}: Pick<
+  MergeBranchOptions,
+  "domainRoot" | "org" | "project" | "branch"
+>): string {
+  return `${domainRoot}/api/orgs/${encodeURIComponent(org)}/projects/${encodeURIComponent(project)}/branches/${encodeURIComponent(branch)}/merge`;
+}
+
+export async function mergeBranch({
   domainRoot,
   apiKey,
   org,
   project,
   branch,
-}: MergeBranchOptions): Promise<void> {
-  const url = `${domainRoot}/api/orgs/${encodeURIComponent(org)}/projects/${encodeURIComponent(project)}/branches/${encodeURIComponent(branch)}/merge`;
+}: MergeBranchOptions): Promise<MergeBranchResult> {
+  const url = buildMergeBranchUrl({ domainRoot, org, project, branch });
 
   let response: Response;
   try {
@@ -26,31 +55,46 @@ export async function mergeBranchCommand({
       },
     });
   } catch (error) {
-    console.error(
-      `Failed to merge branch at ${url}: ${describeFetchError(error)}`,
-    );
-    process.exit(1);
+    return {
+      ok: false,
+      error: `Failed to merge branch at ${url}: ${describeFetchError(error)}`,
+    };
   }
 
-  let data:
-    | { keysMoved?: number; keysDeleted?: number; error?: string }
-    | null = null;
+  let data: MergeApiResponse | null = null;
   try {
-    data = await response.json();
+    data = (await response.json()) as MergeApiResponse;
   } catch {
     // Empty or non-JSON body — fall back to statusText below.
   }
 
   if (response.ok) {
+    return {
+      ok: true,
+      keysMoved: data?.keysMoved ?? 0,
+      keysDeleted: data?.keysDeleted ?? 0,
+    };
+  }
+
+  const errorMessage = data?.error ?? response.statusText;
+  return {
+    ok: false,
+    error: `Failed to merge branch (${response.status} ${response.statusText}): ${errorMessage}`,
+  };
+}
+
+export async function mergeBranchCommand(
+  options: MergeBranchOptions,
+): Promise<void> {
+  const result = await mergeBranch(options);
+
+  if (result.ok) {
     console.log(
-      `Branch "${branch}" merged on project "${project}": ${data?.keysMoved ?? 0} keys moved, ${data?.keysDeleted ?? 0} deleted.`,
+      `Branch "${options.branch}" merged on project "${options.project}": ${result.keysMoved} keys moved, ${result.keysDeleted} deleted.`,
     );
     return;
   }
 
-  const errorMessage = data?.error ?? response.statusText;
-  console.error(
-    `Failed to merge branch (${response.status} ${response.statusText}): ${errorMessage}`,
-  );
+  console.error(result.error);
   process.exit(1);
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -148,4 +148,25 @@ program
     );
   });
 
+program
+  .command("merge:config")
+  .description(
+    "Merge an open translation branch into main using configuration from config file",
+  )
+  .option(
+    "-c, --config <config>",
+    "Path to config file",
+    "transi-store.config.json",
+  )
+  .requiredOption(
+    "-b, --branch <branch>",
+    "Branch slug to merge (e.g. Git head ref used with upload:config)",
+  )
+  .addOption(apiKeyOption)
+  .action((options) => {
+    console.log(
+      `[transi-store] merge:config is not implemented yet (branch: ${options.branch}, config: ${options.config}). No API call was made.`,
+    );
+  });
+
 program.parse();

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -11,6 +11,7 @@ import {
   type UploadOneOptions,
 } from "./uploadTranslations.ts";
 import { mergeBranchCommand } from "./branchMerge.ts";
+import { mergeForConfig } from "./mergeForConfig.ts";
 import {
   DEFAULT_DOMAIN_ROOT,
   ALL_BRANCHES_VALUE,
@@ -147,6 +148,20 @@ program
       validateStrategy(options.strategy),
       options.branch,
     );
+  });
+
+program
+  .command("merge")
+  .description("Merge a translation branch for every project in the config")
+  .addOption(apiKeyOption)
+  .option(
+    "-c, --config <config>",
+    "Path to config file",
+    "transi-store.config.json",
+  )
+  .requiredOption("-b, --branch <branch>", "Branch slug to merge")
+  .action((options) => {
+    mergeForConfig(options.config, options.apiKey, options.branch);
   });
 
 program

--- a/packages/cli/src/mergeForConfig.test.ts
+++ b/packages/cli/src/mergeForConfig.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import { runMergeForConfig } from "./mergeForConfig.ts";
+import type { MergeBranchOptions, MergeBranchResult } from "./branchMerge.ts";
+
+describe("runMergeForConfig", () => {
+  it("calls merge once per project declared in the config", async () => {
+    const merge = vi.fn(
+      async (_options: MergeBranchOptions): Promise<MergeBranchResult> => ({
+        ok: true,
+        keysMoved: 2,
+        keysDeleted: 0,
+      }),
+    );
+
+    const summary = await runMergeForConfig(
+      "transi-store.config.json",
+      "api-key",
+      "feature-1",
+      {
+        readConfig: async () => ({
+          org: "acme",
+          projects: [{ project: "website" }, { project: "mobile" }],
+        }),
+        merge,
+      },
+    );
+
+    expect(merge).toHaveBeenCalledTimes(2);
+    expect(merge.mock.calls[0]![0]).toMatchObject({
+      domainRoot: "https://transi-store.com",
+      apiKey: "api-key",
+      org: "acme",
+      project: "website",
+      branch: "feature-1",
+    });
+    expect(merge.mock.calls[1]![0]).toMatchObject({
+      project: "mobile",
+      branch: "feature-1",
+    });
+    expect(summary).toMatchObject({ total: 2, succeeded: 2, failed: 0 });
+  });
+
+  it("uses the domainRoot from the config when provided", async () => {
+    const merge = vi.fn(
+      async (_options: MergeBranchOptions): Promise<MergeBranchResult> => ({
+        ok: true,
+        keysMoved: 0,
+        keysDeleted: 0,
+      }),
+    );
+
+    await runMergeForConfig("transi-store.config.json", "api-key", "branch-x", {
+      readConfig: async () => ({
+        domainRoot: "https://staging.transi-store.com",
+        org: "acme",
+        projects: [{ project: "website" }],
+      }),
+      merge,
+    });
+
+    expect(merge.mock.calls[0]![0]).toMatchObject({
+      domainRoot: "https://staging.transi-store.com",
+    });
+  });
+
+  it("collects failures without throwing and reports them in the summary", async () => {
+    const merge = vi.fn(
+      async (options: MergeBranchOptions): Promise<MergeBranchResult> => {
+        if (options.project === "mobile") {
+          return { ok: false, error: "boom" };
+        }
+        return { ok: true, keysMoved: 1, keysDeleted: 0 };
+      },
+    );
+
+    const summary = await runMergeForConfig(
+      "transi-store.config.json",
+      "api-key",
+      "feature-1",
+      {
+        readConfig: async () => ({
+          org: "acme",
+          projects: [{ project: "website" }, { project: "mobile" }],
+        }),
+        merge,
+      },
+    );
+
+    expect(summary.total).toBe(2);
+    expect(summary.succeeded).toBe(1);
+    expect(summary.failed).toBe(1);
+    expect(summary.results[1]!.result).toEqual({ ok: false, error: "boom" });
+  });
+
+  it("throws when the config does not match the schema", async () => {
+    await expect(
+      runMergeForConfig("transi-store.config.json", "api-key", "feature-1", {
+        readConfig: async () => ({ projects: [] }),
+        merge: vi.fn(),
+      }),
+    ).rejects.toThrow(/Config validation error/);
+  });
+});

--- a/packages/cli/src/mergeForConfig.ts
+++ b/packages/cli/src/mergeForConfig.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { styleText } from "node:util";
+import { DEFAULT_DOMAIN_ROOT, configSchema } from "@transi-store/common";
+import z from "zod";
+import { mergeBranch, type MergeBranchResult } from "./branchMerge.ts";
+
+type MergeForConfigDeps = {
+  readConfig?: (configPath: string) => Promise<unknown>;
+  merge?: typeof mergeBranch;
+};
+
+type ProjectResult = {
+  project: string;
+  result: MergeBranchResult;
+};
+
+type MergeForConfigSummary = {
+  total: number;
+  succeeded: number;
+  failed: number;
+  results: Array<ProjectResult>;
+};
+
+async function defaultReadConfig(configPath: string): Promise<unknown> {
+  const cwd = process.cwd();
+  const fullPath = path.resolve(cwd, configPath);
+
+  if (!fs.existsSync(fullPath)) {
+    throw new Error(`Config file not found: ${configPath}`);
+  }
+
+  return (
+    await import(pathToFileURL(fullPath).href, { with: { type: "json" } })
+  ).default;
+}
+
+/**
+ * Runs the branch merge for every project declared in the config file.
+ * Returns a summary so callers (CLI or tests) can render or assert the result.
+ */
+export async function runMergeForConfig(
+  configPath: string,
+  apiKey: string,
+  branch: string,
+  deps: MergeForConfigDeps = {},
+): Promise<MergeForConfigSummary> {
+  const readConfig = deps.readConfig ?? defaultReadConfig;
+  const merge = deps.merge ?? mergeBranch;
+
+  const config = await readConfig(configPath);
+  const parsed = configSchema.safeParse(config);
+  if (!parsed.success) {
+    throw new Error(
+      `Config validation error: ${z.prettifyError(parsed.error)}`,
+    );
+  }
+
+  const domainRoot = parsed.data.domainRoot ?? DEFAULT_DOMAIN_ROOT;
+
+  const results: Array<ProjectResult> = [];
+  for (const item of parsed.data.projects) {
+    const result = await merge({
+      domainRoot,
+      apiKey,
+      org: parsed.data.org,
+      project: item.project,
+      branch,
+    });
+    results.push({ project: item.project, result });
+  }
+
+  const succeeded = results.filter((r) => r.result.ok).length;
+  return {
+    total: results.length,
+    succeeded,
+    failed: results.length - succeeded,
+    results,
+  };
+}
+
+export async function mergeForConfig(
+  configPath: string,
+  apiKey: string,
+  branch: string,
+): Promise<void> {
+  let summary: MergeForConfigSummary;
+  try {
+    summary = await runMergeForConfig(configPath, apiKey, branch);
+  } catch (error) {
+    console.error(
+      styleText("red", error instanceof Error ? error.message : String(error)),
+    );
+    process.exit(1);
+  }
+
+  console.log();
+  console.log(styleText(["bold", "cyan"], "↳ Merging translation branch"));
+  console.log(styleText("dim", `  Branch : ${branch}`));
+  console.log();
+
+  for (const { project, result } of summary.results) {
+    if (result.ok) {
+      console.log(
+        `  ${styleText("green", "✓")} ${styleText("bold", project)} ${styleText(
+          "dim",
+          `→ ${result.keysMoved} keys moved, ${result.keysDeleted} deleted`,
+        )}`,
+      );
+    } else {
+      console.log(
+        `  ${styleText("red", "✗")} ${styleText("bold", project)} — ${styleText(
+          "red",
+          result.error,
+        )}`,
+      );
+    }
+  }
+
+  console.log();
+  if (summary.failed === 0) {
+    console.log(
+      styleText(
+        ["green", "bold"],
+        `✓ Branch "${branch}" merged on ${summary.total} project${summary.total > 1 ? "s" : ""}`,
+      ),
+    );
+  } else {
+    console.log(
+      styleText(
+        ["red", "bold"],
+        `✗ ${summary.failed} of ${summary.total} project${summary.total > 1 ? "s" : ""} failed`,
+      ),
+    );
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/uploadTranslations.ts
+++ b/packages/cli/src/uploadTranslations.ts
@@ -1,8 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { DEFAULT_DOMAIN_ROOT } from "@transi-store/common";
-import { ImportStrategy } from "@transi-store/common";
+import {
+  configSchema,
+  createImportErrorResponseSchema,
+  createImportSuccessResponseSchema,
+  DEFAULT_DOMAIN_ROOT,
+  ImportStrategy,
+} from "@transi-store/common";
 import z from "zod";
 import {
   getDefaultBranch,
@@ -10,12 +15,14 @@ import {
   isGitRepository,
   resolveGitBranch,
 } from "./git.ts";
-import { configSchema } from "@transi-store/common";
 import {
   describeFetchError,
   fetchProjectMetadata,
 } from "./fetchProjectMetadata.ts";
 import { pickFile, resolveFilePath } from "./fileHelper.ts";
+
+const importSuccessResponseSchema = createImportSuccessResponseSchema();
+const importErrorResponseSchema = createImportErrorResponseSchema();
 
 export type UploadOneOptions = {
   domainRoot: string;
@@ -130,30 +137,45 @@ async function uploadTranslations({
     process.exit(1);
   }
 
+  let rawBody: unknown;
   try {
-    const data = await response.json();
-
-    if (!response.ok) {
-      console.error(
-        `Failed to import translations: ${response.status} ${response.statusText}\n`,
-        data.error,
-        data.details ? `\nDetails: ${data.details}` : "",
-      );
-      process.exit(1);
-    }
-
-    console.log(
-      `Translations imported for ${logLabel({ project, fileName, locale })}:`,
-    );
-    console.log(`  Total keys: ${data.stats.total}`);
-    console.log(`  Keys created: ${data.stats.keysCreated}`);
-    console.log(`  Translations created: ${data.stats.translationsCreated}`);
-    console.log(`  Translations updated: ${data.stats.translationsUpdated}`);
-    console.log(`  Translations skipped: ${data.stats.translationsSkipped}`);
+    rawBody = await response.json();
   } catch (error) {
     console.error("Error importing translations:", error);
     process.exit(1);
   }
+
+  if (!response.ok) {
+    const parsedError = importErrorResponseSchema.safeParse(rawBody);
+    const errorMessage = parsedError.success
+      ? parsedError.data.error
+      : response.statusText;
+    const details = parsedError.success ? parsedError.data.details : undefined;
+    console.error(
+      `Failed to import translations: ${response.status} ${response.statusText}\n`,
+      errorMessage,
+      details ? `\nDetails: ${details}` : "",
+    );
+    process.exit(1);
+  }
+
+  const parsed = importSuccessResponseSchema.safeParse(rawBody);
+  if (!parsed.success) {
+    console.error(
+      `Unexpected response from import endpoint: ${parsed.error.message}`,
+    );
+    process.exit(1);
+  }
+
+  const { stats } = parsed.data;
+  console.log(
+    `Translations imported for ${logLabel({ project, fileName, locale })}:`,
+  );
+  console.log(`  Total keys: ${stats.total}`);
+  console.log(`  Keys created: ${stats.keysCreated}`);
+  console.log(`  Translations created: ${stats.translationsCreated}`);
+  console.log(`  Translations updated: ${stats.translationsUpdated}`);
+  console.log(`  Translations skipped: ${stats.translationsSkipped}`);
 }
 
 export async function uploadForConfig(

--- a/packages/cli/src/uploadTranslations.ts
+++ b/packages/cli/src/uploadTranslations.ts
@@ -137,12 +137,13 @@ async function uploadTranslations({
     process.exit(1);
   }
 
-  let rawBody: unknown;
+  let rawBody: unknown = undefined;
   try {
     rawBody = await response.json();
-  } catch (error) {
-    console.error("Error importing translations:", error);
-    process.exit(1);
+  } catch {
+    // Empty or non-JSON body — fall through; the !response.ok branch will
+    // fall back to statusText, and the success branch will surface a clear
+    // "unexpected response" error via safeParse.
   }
 
   if (!response.ok) {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -42,5 +42,6 @@
     "noUncheckedSideEffectImports": true,
     "moduleDetection": "force",
     "skipLibCheck": true
-  }
+  },
+  "include": ["src/**/*"]
 }

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/common/src/branch-merge-schema.ts
+++ b/packages/common/src/branch-merge-schema.ts
@@ -1,0 +1,31 @@
+import z from "zod";
+
+// Exposed as factories so consumers can run `extendZodWithOpenApi(z)` BEFORE
+// the zod objects are created. See ./project-schema.ts for the same pattern.
+
+export function createBranchMergeSuccessResponseSchema() {
+  return z.object({
+    success: z.literal(true),
+    keysMoved: z
+      .number()
+      .int()
+      .describe("Number of branch keys moved to the main branch."),
+    keysDeleted: z
+      .number()
+      .int()
+      .describe("Number of main keys soft-deleted by the merge."),
+  });
+}
+
+export function createBranchMergeErrorResponseSchema() {
+  return z.object({
+    error: z.string().describe("Human-readable error message."),
+  });
+}
+
+export type BranchMergeSuccessResponse = z.infer<
+  ReturnType<typeof createBranchMergeSuccessResponseSchema>
+>;
+export type BranchMergeErrorResponse = z.infer<
+  ReturnType<typeof createBranchMergeErrorResponseSchema>
+>;

--- a/packages/common/src/branch-merge-schema.ts
+++ b/packages/common/src/branch-merge-schema.ts
@@ -19,6 +19,7 @@ export function createBranchMergeSuccessResponseSchema() {
 
 export function createBranchMergeErrorResponseSchema() {
   return z.object({
+    success: z.literal(false),
     error: z.string().describe("Human-readable error message."),
   });
 }

--- a/packages/common/src/export-schema.ts
+++ b/packages/common/src/export-schema.ts
@@ -1,0 +1,36 @@
+import z from "zod";
+import { ALL_BRANCHES_VALUE } from "./constants.ts";
+import { SUPPORTED_FORMATS_LIST, SupportedFormat } from "./supported-format.ts";
+
+// Exposed as factories so consumers can run `extendZodWithOpenApi(z)` BEFORE
+// the zod objects are created. See ./project-schema.ts for the same pattern.
+
+export function createExportQuerySchema() {
+  return z.object({
+    format: z
+      .enum(SupportedFormat)
+      .describe(`Output format. Supported formats: ${SUPPORTED_FORMATS_LIST}.`),
+    locale: z
+      .string()
+      .describe(
+        "Language code to export (must match one of the project's configured languages).",
+      ),
+    branch: z
+      .string()
+      .optional()
+      .describe(
+        `Branch slug. When set, translations from this branch are merged on top of main translations. Use "${ALL_BRANCHES_VALUE}" to export all translations across every branch (no branch filtering). Omit to export the main branch only.`,
+      ),
+  });
+}
+
+export function createExportErrorResponseSchema() {
+  return z.object({
+    error: z.string().describe("Human-readable error message."),
+  });
+}
+
+export type ExportQuery = z.infer<ReturnType<typeof createExportQuerySchema>>;
+export type ExportErrorResponse = z.infer<
+  ReturnType<typeof createExportErrorResponseSchema>
+>;

--- a/packages/common/src/import-schema.ts
+++ b/packages/common/src/import-schema.ts
@@ -1,0 +1,81 @@
+import z from "zod";
+import { ImportStrategy } from "./import-strategy.ts";
+import { SUPPORTED_FORMATS_LIST, SupportedFormat } from "./supported-format.ts";
+
+// Exposed as factories so consumers can run `extendZodWithOpenApi(z)` BEFORE
+// the zod objects are created. See ./project-schema.ts for the same pattern.
+
+export function createImportFieldsSchema() {
+  return z.object({
+    locale: z
+      .string()
+      .describe(
+        "Language code to import into (must match one of the project's configured languages).",
+      ),
+    strategy: z
+      .enum(ImportStrategy)
+      .describe(
+        "Import strategy. 'overwrite' updates existing translations. 'skip' only creates missing translations and leaves existing ones untouched.",
+      ),
+    format: z
+      .enum(SupportedFormat)
+      .optional()
+      .describe(
+        `File format (${SUPPORTED_FORMATS_LIST}). Auto-detected from file extension if omitted.`,
+      ),
+    branch: z
+      .string()
+      .optional()
+      .describe(
+        "Target branch slug. If the branch does not exist and has an open status, it will be created automatically. Omit to import into the main branch.",
+      ),
+  });
+}
+
+export function createImportStatsSchema() {
+  return z.object({
+    total: z
+      .number()
+      .describe("Total number of entries processed from the file."),
+    keysCreated: z.number().describe("Number of new translation keys created."),
+    translationsCreated: z
+      .number()
+      .describe("Number of new translations added."),
+    translationsUpdated: z
+      .number()
+      .describe(
+        "Number of existing translations updated (only with 'overwrite' strategy).",
+      ),
+    translationsSkipped: z
+      .number()
+      .describe(
+        "Number of existing translations left untouched (only with 'skip' strategy).",
+      ),
+  });
+}
+
+export function createImportSuccessResponseSchema() {
+  return z.object({
+    success: z.literal(true),
+    stats: createImportStatsSchema(),
+  });
+}
+
+export function createImportErrorResponseSchema() {
+  return z.object({
+    error: z.string().describe("Human-readable error message."),
+    details: z
+      .string()
+      .optional()
+      .describe("Additional technical details about the error."),
+  });
+}
+
+export type ImportFields = z.infer<ReturnType<typeof createImportFieldsSchema>>;
+export type ImportStats = z.infer<ReturnType<typeof createImportStatsSchema>>;
+export type ImportSuccessResponse = z.infer<
+  ReturnType<typeof createImportSuccessResponseSchema>
+>;
+export type ImportErrorResponse = z.infer<
+  ReturnType<typeof createImportErrorResponseSchema>
+>;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -19,3 +19,9 @@ export {
   type ProjectLanguage,
   type ProjectDetail,
 } from "./project-schema.ts";
+export {
+  createBranchMergeSuccessResponseSchema,
+  createBranchMergeErrorResponseSchema,
+  type BranchMergeSuccessResponse,
+  type BranchMergeErrorResponse,
+} from "./branch-merge-schema.ts";

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -25,3 +25,19 @@ export {
   type BranchMergeSuccessResponse,
   type BranchMergeErrorResponse,
 } from "./branch-merge-schema.ts";
+export {
+  createImportFieldsSchema,
+  createImportStatsSchema,
+  createImportSuccessResponseSchema,
+  createImportErrorResponseSchema,
+  type ImportFields,
+  type ImportStats,
+  type ImportSuccessResponse,
+  type ImportErrorResponse,
+} from "./import-schema.ts";
+export {
+  createExportQuerySchema,
+  createExportErrorResponseSchema,
+  type ExportQuery,
+  type ExportErrorResponse,
+} from "./export-schema.ts";

--- a/turbo.json
+++ b/turbo.json
@@ -31,6 +31,10 @@
     "//#upload-translations": {
       "dependsOn": ["@transi-store/cli#build"],
       "env": ["TRANSI_STORE_API_KEY"]
+    },
+    "//#merge-translations": {
+      "dependsOn": ["@transi-store/cli#build"],
+      "env": ["TRANSI_STORE_API_KEY"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -32,7 +32,7 @@
       "dependsOn": ["@transi-store/cli#build"],
       "env": ["TRANSI_STORE_API_KEY"]
     },
-    "//#merge-translations": {
+    "//#merge-translation-branch": {
       "dependsOn": ["@transi-store/cli#build"],
       "env": ["TRANSI_STORE_API_KEY"]
     }

--- a/turbo.json
+++ b/turbo.json
@@ -22,7 +22,8 @@
     "test": {
       "dependsOn": ["^test"],
       "persistent": true,
-      "cache": false
+      "cache": false,
+      "env": ["SESSION_SECRET", "NODE_ENV"]
     },
     "//#download-translations": {
       "dependsOn": ["@transi-store/cli#build"],

--- a/turbo.json
+++ b/turbo.json
@@ -25,6 +25,15 @@
       "cache": false,
       "env": ["SESSION_SECRET", "NODE_ENV"]
     },
+    "react-router-typegen": {
+      "dependsOn": ["^react-router-typegen"]
+    },
+    "//#knip": {
+      "dependsOn": [
+        "@transi-store/common#build",
+        "@transi-store/website#react-router-typegen"
+      ]
+    },
     "//#download-translations": {
       "dependsOn": ["@transi-store/cli#build"],
       "env": ["TRANSI_STORE_API_KEY"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4130,6 +4130,7 @@ __metadata:
     rolldown: "npm:^1.0.0-rc.12"
     simple-git: "npm:^3.33.0"
     typescript: "npm:^5.7.3"
+    vitest: "npm:^4.0.18"
     zod: "npm:^4.3.6"
   bin:
     transi-store: ./dist/cli.js


### PR DESCRIPTION
test d'action github pour merge une branch dans transi-store une fois qu'elle est mergée dans github (mais l'api / cli n'existe pas encore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow de fusion des branches de traduction (automatique à la fermeture d’un PR ou lancement manuel).
  * Commande CLI `merge` pour lancer des fusions multi-projets depuis une configuration.

* **Chores**
  * Ajustements de scripts de test et de build, nouvelle tâche Turbo et mises à jour de la config locale.
  * Ajout de schémas Zod partagés pour import/export/merge réutilisables entre paquets.

* **Tests**
  * Suites Vitest ajoutées couvrant la logique de merge et l’exécution par configuration.

* **Documentation**
  * Clarification et centralisation des notes OpenAPI et de la doc de l’API de merge.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/transi-store/transi-store/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->