### PR TITLE
feat: expose branch merge via API and CLI

### DIFF
--- a/.changeset/branch-merge-cli.md
+++ b/.changeset/branch-merge-cli.md
@@ -1,0 +1,5 @@
+---
+"@transi-store/cli": minor
+---
+
+Add `branch:merge` command to merge a project branch into main from the CLI. The command targets the new `POST /api/orgs/:orgSlug/projects/:projectSlug/branches/:branchSlug/merge` endpoint. `--branch` is required (no git auto-detection). On conflict the command exits `1` and prints the colliding keys.

--- a/apps/website/app/docs/de/developer.mdx
+++ b/apps/website/app/docs/de/developer.mdx
@@ -213,4 +213,21 @@ transi-store upload --org acme --project webapp --locale fr --input ./locales/fr
 
 > **Git-Optimierung:** `upload:config` überspringt zudem Dateien, die sich im Vergleich zum Standard-Branch (`main`/`master`) nicht geändert haben, wenn sie in einem Git-Repository ausgeführt werden, um unnötige API-Aufrufe zu vermeiden.
 
+### Einen Branch zusammenführen
+
+```bash
+# Branch in main zusammenführen
+transi-store branch:merge --org acme --project webapp --branch feature/my-feature
+```
+
+`--branch` ist erforderlich (keine automatische Erkennung): da das Zusammenführen destruktiv ist, muss der Ziel-Branch explizit angegeben werden. Bei Erfolg werden die Keys des Branches in main übernommen und alle zur Löschung markierten Keys werden (soft) gelöscht. Falls Branch-Keys mit bestehenden Main-Keys kollidieren, beendet sich der Befehl mit Exit-Code `1` und gibt die in Konflikt stehenden Keys aus.
+
+Sie können den Endpoint auch direkt aufrufen:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $TRANSI_STORE_API_KEY" \
+  "https://transi-store.com/api/orgs/acme/projects/webapp/branches/feature/my-feature/merge"
+```
+
 Dies ist ideal für die Integration in CI/CD — laden Sie übersetzte Strings zur Build-Zeit herunter und laden Sie neue Quell-Strings hoch, nachdem Entwickler sie hinzugefügt haben.

--- a/apps/website/app/docs/de/developer.mdx
+++ b/apps/website/app/docs/de/developer.mdx
@@ -220,14 +220,14 @@ transi-store upload --org acme --project webapp --locale fr --input ./locales/fr
 transi-store branch:merge --org acme --project webapp --branch feature/my-feature
 ```
 
-`--branch` ist erforderlich (keine automatische Erkennung): da das Zusammenführen destruktiv ist, muss der Ziel-Branch explizit angegeben werden. Bei Erfolg werden die Keys des Branches in main übernommen und alle zur Löschung markierten Keys werden (soft) gelöscht. Falls Branch-Keys mit bestehenden Main-Keys kollidieren, beendet sich der Befehl mit Exit-Code `1` und gibt die in Konflikt stehenden Keys aus.
+`--branch` ist erforderlich (keine automatische Erkennung): da das Zusammenführen destruktiv ist, muss der Ziel-Branch explizit angegeben werden. Bei Erfolg werden die Keys des Branches in main übernommen und alle zur Löschung markierten Keys werden (soft) gelöscht.
 
-Sie können den Endpoint auch direkt aufrufen:
+Sie können den Endpoint auch direkt aufrufen (Pfadsegmente müssen URL-kodiert sein, z. B. wird `/` in einem Branch-Slug zu `%2F`):
 
 ```bash
 curl -X POST \
   -H "Authorization: Bearer $TRANSI_STORE_API_KEY" \
-  "https://transi-store.com/api/orgs/acme/projects/webapp/branches/feature/my-feature/merge"
+  "https://transi-store.com/api/orgs/acme/projects/webapp/branches/feature%2Fmy-feature/merge"
 ```
 
 Dies ist ideal für die Integration in CI/CD — laden Sie übersetzte Strings zur Build-Zeit herunter und laden Sie neue Quell-Strings hoch, nachdem Entwickler sie hinzugefügt haben.

--- a/apps/website/app/docs/en/developer.mdx
+++ b/apps/website/app/docs/en/developer.mdx
@@ -220,14 +220,14 @@ transi-store upload --org acme --project webapp --locale fr --input ./locales/fr
 transi-store branch:merge --org acme --project webapp --branch feature/my-feature
 ```
 
-`--branch` is required (no auto-detection): merging is destructive, so the target branch must be explicit. On success the branch's keys are moved to main and any keys marked for deletion are soft-deleted. If some branch keys collide with existing main keys, the command exits with code `1` and prints the conflicting keys.
+`--branch` is required (no auto-detection): merging is destructive, so the target branch must be explicit. On success the branch's keys are moved to main and any keys marked for deletion are soft-deleted.
 
-You can also call the underlying endpoint directly:
+You can also call the underlying endpoint directly (path segments must be URL-encoded, e.g. `/` in a branch slug becomes `%2F`):
 
 ```bash
 curl -X POST \
   -H "Authorization: Bearer $TRANSI_STORE_API_KEY" \
-  "https://transi-store.com/api/orgs/acme/projects/webapp/branches/feature/my-feature/merge"
+  "https://transi-store.com/api/orgs/acme/projects/webapp/branches/feature%2Fmy-feature/merge"
 ```
 
 This is ideal for integrating into CI/CD — download translated strings at build time and upload new source strings after developers add them.

--- a/apps/website/app/docs/en/developer.mdx
+++ b/apps/website/app/docs/en/developer.mdx
@@ -213,4 +213,21 @@ transi-store upload --org acme --project webapp --locale fr --input ./locales/fr
 
 > **Git optimization:** `upload:config` also skips files that have not changed compared to the default branch (`main`/`master`) when running in a git repository, to avoid unnecessary API calls.
 
+### Merging a branch
+
+```bash
+# Merge a branch into main
+transi-store branch:merge --org acme --project webapp --branch feature/my-feature
+```
+
+`--branch` is required (no auto-detection): merging is destructive, so the target branch must be explicit. On success the branch's keys are moved to main and any keys marked for deletion are soft-deleted. If some branch keys collide with existing main keys, the command exits with code `1` and prints the conflicting keys.
+
+You can also call the underlying endpoint directly:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $TRANSI_STORE_API_KEY" \
+  "https://transi-store.com/api/orgs/acme/projects/webapp/branches/feature/my-feature/merge"
+```
+
 This is ideal for integrating into CI/CD — download translated strings at build time and upload new source strings after developers add them.

--- a/apps/website/app/docs/es/developer.mdx
+++ b/apps/website/app/docs/es/developer.mdx
@@ -220,14 +220,14 @@ transi-store upload --org acme --project webapp --locale fr --input ./locales/fr
 transi-store branch:merge --org acme --project webapp --branch feature/my-feature
 ```
 
-`--branch` es obligatorio (no hay detección automática): la fusión es destructiva, por lo que la rama objetivo debe ser explícita. Si la operación tiene éxito, las claves de la rama se trasladan a main y aquellas marcadas para eliminación se eliminan (soft delete). Si algunas claves de la rama entran en conflicto con claves existentes en main, el comando termina con código `1` y muestra las claves en conflicto.
+`--branch` es obligatorio (no hay detección automática): la fusión es destructiva, por lo que la rama objetivo debe ser explícita. Si la operación tiene éxito, las claves de la rama se trasladan a main y aquellas marcadas para eliminación se eliminan (soft delete).
 
-También puedes llamar directamente al endpoint:
+También puedes llamar directamente al endpoint (los segmentos de la ruta deben estar codificados en URL, por ejemplo `/` en un slug de rama se convierte en `%2F`):
 
 ```bash
 curl -X POST \
   -H "Authorization: Bearer $TRANSI_STORE_API_KEY" \
-  "https://transi-store.com/api/orgs/acme/projects/webapp/branches/feature/my-feature/merge"
+  "https://transi-store.com/api/orgs/acme/projects/webapp/branches/feature%2Fmy-feature/merge"
 ```
 
 Esto es ideal para integrar en CI/CD: descargue cadenas traducidas durante el tiempo de compilación y cargue nuevas cadenas de origen después de que los desarrolladores las añadan.

--- a/apps/website/app/docs/es/developer.mdx
+++ b/apps/website/app/docs/es/developer.mdx
@@ -213,4 +213,21 @@ transi-store upload --org acme --project webapp --locale fr --input ./locales/fr
 
 > **Optimización de Git:** `upload:config` también omite los archivos que no han cambiado en comparación con la rama predeterminada (`main`/`master`) al ejecutarse en un repositorio git, para evitar llamadas innecesarias a la API.
 
+### Fusionar una rama
+
+```bash
+# Fusionar una rama en main
+transi-store branch:merge --org acme --project webapp --branch feature/my-feature
+```
+
+`--branch` es obligatorio (no hay detección automática): la fusión es destructiva, por lo que la rama objetivo debe ser explícita. Si la operación tiene éxito, las claves de la rama se trasladan a main y aquellas marcadas para eliminación se eliminan (soft delete). Si algunas claves de la rama entran en conflicto con claves existentes en main, el comando termina con código `1` y muestra las claves en conflicto.
+
+También puedes llamar directamente al endpoint:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $TRANSI_STORE_API_KEY" \
+  "https://transi-store.com/api/orgs/acme/projects/webapp/branches/feature/my-feature/merge"
+```
+
 Esto es ideal para integrar en CI/CD: descargue cadenas traducidas durante el tiempo de compilación y cargue nuevas cadenas de origen después de que los desarrolladores las añadan.

--- a/apps/website/app/docs/fr/developer.mdx
+++ b/apps/website/app/docs/fr/developer.mdx
@@ -220,14 +220,14 @@ transi-store upload --org acme --project webapp --locale fr --input ./locales/fr
 transi-store branch:merge --org acme --project webapp --branch feature/my-feature
 ```
 
-`--branch` est obligatoire (pas de détection automatique) : la fusion étant destructive, la branche cible doit être explicite. En cas de succès, les clés de la branche sont déplacées sur main et celles marquées pour suppression sont supprimées (soft delete). Si certaines clés de la branche entrent en conflit avec des clés existantes sur main, la commande retourne avec le code `1` et affiche les clés conflictuelles.
+`--branch` est obligatoire (pas de détection automatique) : la fusion étant destructive, la branche cible doit être explicite. En cas de succès, les clés de la branche sont déplacées sur main et celles marquées pour suppression sont supprimées (soft delete).
 
-Vous pouvez aussi appeler directement l'endpoint :
+Vous pouvez aussi appeler directement l'endpoint (les segments du chemin doivent être encodés en URL, par exemple `/` dans un slug de branche devient `%2F`) :
 
 ```bash
 curl -X POST \
   -H "Authorization: Bearer $TRANSI_STORE_API_KEY" \
-  "https://transi-store.com/api/orgs/acme/projects/webapp/branches/feature/my-feature/merge"
+  "https://transi-store.com/api/orgs/acme/projects/webapp/branches/feature%2Fmy-feature/merge"
 ```
 
 Ceci est idéal pour l'intégration en CI/CD — téléchargez les chaînes traduites au moment de la compilation et téléversez les nouvelles chaînes sources après que les développeurs les aient ajoutées.

--- a/apps/website/app/docs/fr/developer.mdx
+++ b/apps/website/app/docs/fr/developer.mdx
@@ -213,4 +213,21 @@ transi-store upload --org acme --project webapp --locale fr --input ./locales/fr
 
 > **Optimisation Git :** `upload:config` ignore également les fichiers qui n'ont pas changé par rapport à la branche par défaut (`main`/`master`) lors de l'exécution dans un dépôt git, afin d'éviter les appels API inutiles.
 
+### Fusionner une branche
+
+```bash
+# Fusionner une branche dans main
+transi-store branch:merge --org acme --project webapp --branch feature/my-feature
+```
+
+`--branch` est obligatoire (pas de détection automatique) : la fusion étant destructive, la branche cible doit être explicite. En cas de succès, les clés de la branche sont déplacées sur main et celles marquées pour suppression sont supprimées (soft delete). Si certaines clés de la branche entrent en conflit avec des clés existantes sur main, la commande retourne avec le code `1` et affiche les clés conflictuelles.
+
+Vous pouvez aussi appeler directement l'endpoint :
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $TRANSI_STORE_API_KEY" \
+  "https://transi-store.com/api/orgs/acme/projects/webapp/branches/feature/my-feature/merge"
+```
+
 Ceci est idéal pour l'intégration en CI/CD — téléchargez les chaînes traduites au moment de la compilation et téléversez les nouvelles chaînes sources après que les développeurs les aient ajoutées.

--- a/apps/website/app/lib/api-doc/openapi.server.ts
+++ b/apps/website/app/lib/api-doc/openapi.server.ts
@@ -18,7 +18,6 @@ import {
 import {
   branchMergeSuccessResponseSchema,
   branchMergeErrorResponseSchema,
-  branchMergeConflictResponseSchema,
 } from "./schemas/branch-merge";
 import {
   getProjectLanguages,
@@ -339,14 +338,6 @@ export async function generateOpenApiDocument(user?: SessionData | null) {
         description: "Method not allowed (only POST is accepted).",
         content: {
           "application/json": { schema: branchMergeErrorResponseSchema },
-        },
-      },
-      409: {
-        description:
-          "Conflict: some branch keys collide with existing main keys. " +
-          "Resolve the conflicts before retrying.",
-        content: {
-          "application/json": { schema: branchMergeConflictResponseSchema },
         },
       },
     },

--- a/apps/website/app/lib/api-doc/openapi.server.ts
+++ b/apps/website/app/lib/api-doc/openapi.server.ts
@@ -16,6 +16,11 @@ import {
   projectDetailErrorResponseSchema,
 } from "./schemas/project-detail";
 import {
+  branchMergeSuccessResponseSchema,
+  branchMergeErrorResponseSchema,
+  branchMergeConflictResponseSchema,
+} from "./schemas/branch-merge";
+import {
   getProjectLanguages,
   getProjectsForOrganization,
 } from "../projects.server";
@@ -70,6 +75,12 @@ export async function generateOpenApiDocument(user?: SessionData | null) {
     param: { name: "fileId", in: "path" },
     description: "Project file identifier.",
     example: projectFileExample?.id ?? "1",
+  });
+
+  const branchSlugParam = z.string().openapi({
+    param: { name: "branchSlug", in: "path" },
+    description: "Branch slug.",
+    example: "feature-xyz",
   });
 
   const importFormSchema = importFieldsSchema(localeExample).extend({
@@ -270,6 +281,72 @@ export async function generateOpenApiDocument(user?: SessionData | null) {
         description: "Method not allowed (only POST is accepted).",
         content: {
           "application/json": { schema: importErrorResponseSchema },
+        },
+      },
+    },
+  });
+
+  // -- Branch merge endpoint --
+  registry.registerPath({
+    method: "post",
+    path: "/api/orgs/{orgSlug}/projects/{projectSlug}/branches/{branchSlug}/merge",
+    summary: "Merge a project branch into main",
+    description:
+      "Merge the branch's keys into the main branch and apply any pending key deletions. " +
+      "The branch's status is set to `merged` on success. " +
+      "When the API is called with an API key, the merge is not attributed to a specific user.",
+    tags: ["Branches"],
+    security: [{ BearerApiKey: [] }],
+    request: {
+      params: z.object({
+        orgSlug: orgSlugParam,
+        projectSlug: projectSlugParam,
+        branchSlug: branchSlugParam,
+      }),
+    },
+    responses: {
+      200: {
+        description: "Branch merged successfully.",
+        content: {
+          "application/json": { schema: branchMergeSuccessResponseSchema },
+        },
+      },
+      400: {
+        description: "Branch is already merged or closed.",
+        content: {
+          "application/json": { schema: branchMergeErrorResponseSchema },
+        },
+      },
+      401: {
+        description: "Missing or invalid API key.",
+        content: {
+          "application/json": { schema: branchMergeErrorResponseSchema },
+        },
+      },
+      403: {
+        description: "The API key does not belong to this organization.",
+        content: {
+          "application/json": { schema: branchMergeErrorResponseSchema },
+        },
+      },
+      404: {
+        description: "Project or branch not found.",
+        content: {
+          "application/json": { schema: branchMergeErrorResponseSchema },
+        },
+      },
+      405: {
+        description: "Method not allowed (only POST is accepted).",
+        content: {
+          "application/json": { schema: branchMergeErrorResponseSchema },
+        },
+      },
+      409: {
+        description:
+          "Conflict: some branch keys collide with existing main keys. " +
+          "Resolve the conflicts before retrying.",
+        content: {
+          "application/json": { schema: branchMergeConflictResponseSchema },
         },
       },
     },

--- a/apps/website/app/lib/api-doc/schemas/branch-merge.ts
+++ b/apps/website/app/lib/api-doc/schemas/branch-merge.ts
@@ -25,16 +25,3 @@ export const branchMergeErrorResponseSchema = z
     }),
   })
   .openapi("BranchMergeError");
-
-export const branchMergeConflictResponseSchema = z
-  .object({
-    error: z.string().openapi({
-      description: "Human-readable error message.",
-      example: "Conflicting keys exist on main",
-    }),
-    conflictingKeys: z.array(z.string()).openapi({
-      description: "Names of the branch keys that collide with main keys.",
-      example: ["home.title", "nav.about"],
-    }),
-  })
-  .openapi("BranchMergeConflict");

--- a/apps/website/app/lib/api-doc/schemas/branch-merge.ts
+++ b/apps/website/app/lib/api-doc/schemas/branch-merge.ts
@@ -1,0 +1,40 @@
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+
+extendZodWithOpenApi(z);
+
+export const branchMergeSuccessResponseSchema = z
+  .object({
+    success: z.literal(true),
+    keysMoved: z.number().int().openapi({
+      description: "Number of branch keys moved to the main branch.",
+      example: 5,
+    }),
+    keysDeleted: z.number().int().openapi({
+      description: "Number of main keys soft-deleted by the merge.",
+      example: 1,
+    }),
+  })
+  .openapi("BranchMergeSuccess");
+
+export const branchMergeErrorResponseSchema = z
+  .object({
+    error: z.string().openapi({
+      description: "Human-readable error message.",
+      example: 'Branch "feature-xyz" not found',
+    }),
+  })
+  .openapi("BranchMergeError");
+
+export const branchMergeConflictResponseSchema = z
+  .object({
+    error: z.string().openapi({
+      description: "Human-readable error message.",
+      example: "Conflicting keys exist on main",
+    }),
+    conflictingKeys: z.array(z.string()).openapi({
+      description: "Names of the branch keys that collide with main keys.",
+      example: ["home.title", "nav.about"],
+    }),
+  })
+  .openapi("BranchMergeConflict");

--- a/apps/website/app/lib/branches.server.test.ts
+++ b/apps/website/app/lib/branches.server.test.ts
@@ -21,7 +21,7 @@ import {
   mergeBranch,
   getBranchKeys,
 } from "./branches.server";
-import { BRANCH_STATUS } from "./branches";
+import { BRANCH_STATUS, MERGE_FAILURE_REASON } from "./branches";
 import type { OAuthProvider } from "./auth-providers";
 
 vi.mock("~/lib/db.server", () => ({
@@ -407,7 +407,7 @@ describe("mergeBranch with deletions", () => {
 
     expect(result).toEqual({
       success: false,
-      reason: "not_open",
+      reason: MERGE_FAILURE_REASON.NOT_OPEN,
       error: "Branch is not open",
     });
   });
@@ -417,7 +417,7 @@ describe("mergeBranch with deletions", () => {
 
     expect(result).toEqual({
       success: false,
-      reason: "not_found",
+      reason: MERGE_FAILURE_REASON.NOT_FOUND,
       error: "Branch not found",
     });
   });

--- a/apps/website/app/lib/branches.server.test.ts
+++ b/apps/website/app/lib/branches.server.test.ts
@@ -407,6 +407,7 @@ describe("mergeBranch with deletions", () => {
 
     expect(result).toEqual({
       success: false,
+      reason: "not_open",
       error: "Branch is not open",
     });
   });
@@ -416,7 +417,27 @@ describe("mergeBranch with deletions", () => {
 
     expect(result).toEqual({
       success: false,
+      reason: "not_found",
       error: "Branch not found",
     });
+  });
+
+  it("persists null mergedBy when called without a user", async () => {
+    await createTranslationKey(db, projectId, "branch.key", { branchId });
+
+    const result = await mergeBranch(branchId, null);
+
+    expect(result).toEqual({
+      success: true,
+      keysMoved: 1,
+      keysDeleted: 0,
+    });
+
+    const merged = await db.query.branches.findFirst({
+      where: { id: branchId },
+    });
+    expect(merged!.status).toBe(BRANCH_STATUS.MERGED);
+    expect(merged!.mergedBy).toBeNull();
+    expect(merged!.mergedAt).not.toBeNull();
   });
 });

--- a/apps/website/app/lib/branches.server.ts
+++ b/apps/website/app/lib/branches.server.ts
@@ -96,9 +96,12 @@ type MergeBranchResult =
       success: false;
       reason: MERGE_FAILURE_REASON;
       error: string;
-      conflictingKeys?: string[];
     };
 
+// Merging a branch never produces a key conflict: the unique index
+// `unique_project_file_key` on (project_id, file_id, key_name) prevents a
+// branch from ever holding a key that already exists on main, so setting
+// branchId = NULL at merge time is always safe.
 export async function mergeBranch(
   branchId: number,
   mergedBy: number | null,
@@ -120,71 +123,49 @@ export async function mergeBranch(
     };
   }
 
-  // Get the keys on this branch
   const branchKeys = await db.query.translationKeys.findMany({
     where: { branchId },
   });
 
-  // Get the key deletions for this branch
   const keyDeletions = await db.query.branchKeyDeletions.findMany({
     where: { branchId },
   });
 
-  // Move keys from branch to main (set branchId = NULL)
-  // The unique constraint (project_id, key_name) ensures no collision
-  try {
-    let keysMoved = 0;
-    let keysDeleted = 0;
+  let keysMoved = 0;
+  let keysDeleted = 0;
 
-    await db.transaction(async (tx) => {
-      if (branchKeys.length > 0) {
-        const [result] = await tx
-          .update(schema.translationKeys)
-          .set({ branchId: null })
-          .where(eq(schema.translationKeys.branchId, branchId))
-          .returning({ id: schema.translationKeys.id });
+  await db.transaction(async (tx) => {
+    if (branchKeys.length > 0) {
+      const [result] = await tx
+        .update(schema.translationKeys)
+        .set({ branchId: null })
+        .where(eq(schema.translationKeys.branchId, branchId))
+        .returning({ id: schema.translationKeys.id });
 
-        keysMoved = result ? branchKeys.length : 0;
-      }
+      keysMoved = result ? branchKeys.length : 0;
+    }
 
-      // Soft-delete keys marked for deletion
-      if (keyDeletions.length > 0) {
-        const deletionKeyIds = keyDeletions.map((d) => d.translationKeyId);
-        await tx
-          .update(schema.translationKeys)
-          .set({ deletedAt: new Date() })
-          .where(inArray(schema.translationKeys.id, deletionKeyIds));
+    if (keyDeletions.length > 0) {
+      const deletionKeyIds = keyDeletions.map((d) => d.translationKeyId);
+      await tx
+        .update(schema.translationKeys)
+        .set({ deletedAt: new Date() })
+        .where(inArray(schema.translationKeys.id, deletionKeyIds));
 
-        keysDeleted = deletionKeyIds.length;
-
-        // Clean up the branch_key_deletions entries
-        await tx
-          .delete(schema.branchKeyDeletions)
-          .where(eq(schema.branchKeyDeletions.branchId, branchId));
-      }
+      keysDeleted = deletionKeyIds.length;
 
       await tx
-        .update(schema.branches)
-        .set({ status: BRANCH_STATUS.MERGED, mergedBy, mergedAt: new Date() })
-        .where(eq(schema.branches.id, branchId));
-    });
-
-    return { success: true, keysMoved, keysDeleted };
-  } catch (error) {
-    // Unique constraint violation = conflict
-    if (
-      error instanceof Error &&
-      error.message.includes("unique_project_key")
-    ) {
-      return {
-        success: false,
-        reason: MERGE_FAILURE_REASON.CONFLICT,
-        error: "Conflicting keys exist on main",
-        conflictingKeys: branchKeys.map((k) => k.keyName),
-      };
+        .delete(schema.branchKeyDeletions)
+        .where(eq(schema.branchKeyDeletions.branchId, branchId));
     }
-    throw error;
-  }
+
+    await tx
+      .update(schema.branches)
+      .set({ status: BRANCH_STATUS.MERGED, mergedBy, mergedAt: new Date() })
+      .where(eq(schema.branches.id, branchId));
+  });
+
+  return { success: true, keysMoved, keysDeleted };
 }
 
 // --- Branch Key Deletions ---

--- a/apps/website/app/lib/branches.server.ts
+++ b/apps/website/app/lib/branches.server.ts
@@ -92,19 +92,24 @@ export async function getBranchKeyCount(branchId: number): Promise<number> {
 
 type MergeBranchResult =
   | { success: true; keysMoved: number; keysDeleted: number }
-  | { success: false; error: string; conflictingKeys?: string[] };
+  | {
+      success: false;
+      reason: "not_found" | "not_open" | "conflict";
+      error: string;
+      conflictingKeys?: string[];
+    };
 
 export async function mergeBranch(
   branchId: number,
-  mergedBy: number,
+  mergedBy: number | null,
 ): Promise<MergeBranchResult> {
   const branch = await getBranchById(branchId);
   if (!branch) {
-    return { success: false, error: "Branch not found" };
+    return { success: false, reason: "not_found", error: "Branch not found" };
   }
 
   if (branch.status !== BRANCH_STATUS.OPEN) {
-    return { success: false, error: "Branch is not open" };
+    return { success: false, reason: "not_open", error: "Branch is not open" };
   }
 
   // Get the keys on this branch
@@ -165,6 +170,7 @@ export async function mergeBranch(
     ) {
       return {
         success: false,
+        reason: "conflict",
         error: "Conflicting keys exist on main",
         conflictingKeys: branchKeys.map((k) => k.keyName),
       };

--- a/apps/website/app/lib/branches.server.ts
+++ b/apps/website/app/lib/branches.server.ts
@@ -1,5 +1,5 @@
 import type { Branch, TranslationKey } from "../../drizzle/schema";
-import { BRANCH_STATUS } from "./branches";
+import { BRANCH_STATUS, MERGE_FAILURE_REASON } from "./branches";
 import { db, schema } from "./db.server";
 import { and, eq, inArray, isNull, notInArray, or, sql } from "drizzle-orm";
 
@@ -94,7 +94,7 @@ type MergeBranchResult =
   | { success: true; keysMoved: number; keysDeleted: number }
   | {
       success: false;
-      reason: "not_found" | "not_open" | "conflict";
+      reason: MERGE_FAILURE_REASON;
       error: string;
       conflictingKeys?: string[];
     };
@@ -105,11 +105,19 @@ export async function mergeBranch(
 ): Promise<MergeBranchResult> {
   const branch = await getBranchById(branchId);
   if (!branch) {
-    return { success: false, reason: "not_found", error: "Branch not found" };
+    return {
+      success: false,
+      reason: MERGE_FAILURE_REASON.NOT_FOUND,
+      error: "Branch not found",
+    };
   }
 
   if (branch.status !== BRANCH_STATUS.OPEN) {
-    return { success: false, reason: "not_open", error: "Branch is not open" };
+    return {
+      success: false,
+      reason: MERGE_FAILURE_REASON.NOT_OPEN,
+      error: "Branch is not open",
+    };
   }
 
   // Get the keys on this branch
@@ -170,7 +178,7 @@ export async function mergeBranch(
     ) {
       return {
         success: false,
-        reason: "conflict",
+        reason: MERGE_FAILURE_REASON.CONFLICT,
         error: "Conflicting keys exist on main",
         conflictingKeys: branchKeys.map((k) => k.keyName),
       };

--- a/apps/website/app/lib/branches.ts
+++ b/apps/website/app/lib/branches.ts
@@ -2,3 +2,9 @@ export enum BRANCH_STATUS {
   OPEN = "open",
   MERGED = "merged",
 }
+
+export enum MERGE_FAILURE_REASON {
+  NOT_FOUND = "not_found",
+  NOT_OPEN = "not_open",
+  CONFLICT = "conflict",
+}

--- a/apps/website/app/lib/branches.ts
+++ b/apps/website/app/lib/branches.ts
@@ -6,5 +6,4 @@ export enum BRANCH_STATUS {
 export enum MERGE_FAILURE_REASON {
   NOT_FOUND = "not_found",
   NOT_OPEN = "not_open",
-  CONFLICT = "conflict",
 }

--- a/apps/website/app/locales/de/translation.json
+++ b/apps/website/app/locales/de/translation.json
@@ -1,4 +1,6 @@
 {
+  "api.branchMerge.branchNotFound": "Branch \"{branchSlug}\" nicht gefunden",
+  "api.branchMerge.branchNotOpen": "Branch \"{branchSlug}\" ist bereits zusammengeführt oder geschlossen",
   "api.methodNotAllowed": "Methode nicht erlaubt",
   "api.methodNotAllowed (copy)": "Methode nicht erlaubt",
   "api.translate.keyNotFound": "Schlüssel nicht gefunden",

--- a/apps/website/app/locales/en/translation.json
+++ b/apps/website/app/locales/en/translation.json
@@ -1,4 +1,6 @@
 {
+  "api.branchMerge.branchNotFound": "Branch \"{branchSlug}\" not found",
+  "api.branchMerge.branchNotOpen": "Branch \"{branchSlug}\" is already merged or closed",
   "api.methodNotAllowed": "Method not allowed",
   "api.methodNotAllowed (copy)": "Method not allowed",
   "api.translate.keyNotFound": "Key not found",

--- a/apps/website/app/locales/es/translation.json
+++ b/apps/website/app/locales/es/translation.json
@@ -1,4 +1,6 @@
 {
+  "api.branchMerge.branchNotFound": "Rama \"{branchSlug}\" no encontrada",
+  "api.branchMerge.branchNotOpen": "La rama \"{branchSlug}\" ya está fusionada o cerrada",
   "api.methodNotAllowed": "Método no permitido",
   "api.methodNotAllowed (copy)": "Método no permitido",
   "api.translate.keyNotFound": "Clave no encontrada",

--- a/apps/website/app/locales/fr/translation.json
+++ b/apps/website/app/locales/fr/translation.json
@@ -1,4 +1,6 @@
 {
+  "api.branchMerge.branchNotFound": "Branche \"{branchSlug}\" non trouvée",
+  "api.branchMerge.branchNotOpen": "La branche \"{branchSlug}\" est déjà fusionnée ou fermée",
   "api.methodNotAllowed": "Méthode non autorisée",
   "api.methodNotAllowed (copy)": "Méthode non autorisée",
   "api.translate.keyNotFound": "Clé non trouvée",

--- a/apps/website/app/routes.ts
+++ b/apps/website/app/routes.ts
@@ -154,6 +154,10 @@ export default [
         "projects/:projectSlug/translate",
         "routes/api.orgs.$orgSlug.projects.$projectSlug.translate.tsx",
       ),
+      route(
+        "projects/:projectSlug/branches/:branchSlug/merge",
+        "routes/api.orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.tsx",
+      ),
     ]),
   ]),
 

--- a/apps/website/app/routes/api.orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.test.ts
+++ b/apps/website/app/routes/api.orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RouterContextProvider } from "react-router";
+import * as schema from "../../drizzle/schema";
+import { eq } from "drizzle-orm";
+import { action } from "./api.orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge";
+import { orgContext } from "~/middleware/api-auth.server";
+import {
+  cleanupDb,
+  createBranch,
+  createOrganization,
+  createProject,
+  createTranslationKey,
+  getTestDb,
+} from "../../tests/test-db";
+import { BRANCH_STATUS } from "~/lib/branches";
+
+vi.mock("~/lib/db.server", () => ({
+  get db() {
+    return getTestDb();
+  },
+  schema,
+}));
+
+describe("Branch merge API", () => {
+  let org: schema.Organization;
+  let project: schema.Project;
+
+  beforeEach(async () => {
+    org = await createOrganization(getTestDb(), { slug: "test-org" });
+    project = await createProject(getTestDb(), org.id, {
+      name: "Test Project",
+      slug: "test-project",
+    });
+  });
+
+  afterEach(async () => {
+    await cleanupDb();
+  });
+
+  function createOrgContext() {
+    const ctx = new RouterContextProvider();
+    ctx.set(orgContext, org);
+    return ctx;
+  }
+
+  function callAction({
+    orgSlug = "test-org",
+    projectSlug = "test-project",
+    branchSlug = "feature-branch",
+    method = "POST",
+  }: {
+    orgSlug?: string;
+    projectSlug?: string;
+    branchSlug?: string;
+    method?: string;
+  } = {}) {
+    const request = new Request(
+      `https://example.com/api/orgs/${orgSlug}/projects/${projectSlug}/branches/${branchSlug}/merge`,
+      { method },
+    );
+    return action({
+      request,
+      params: { orgSlug, projectSlug, branchSlug },
+      unstable_pattern:
+        "/api/orgs/:orgSlug/projects/:projectSlug/branches/:branchSlug/merge",
+      context: createOrgContext(),
+    });
+  }
+
+  it("merges an open branch and stores null mergedBy", async () => {
+    const branch = await createBranch(getTestDb(), project.id);
+    await createTranslationKey(getTestDb(), project.id, "branch.key", {
+      branchId: branch.id,
+    });
+
+    const response = await callAction();
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({
+      success: true,
+      keysMoved: 1,
+      keysDeleted: 0,
+    });
+
+    const [merged] = await getTestDb()
+      .select()
+      .from(schema.branches)
+      .where(eq(schema.branches.id, branch.id));
+    expect(merged.status).toBe(BRANCH_STATUS.MERGED);
+    expect(merged.mergedBy).toBeNull();
+    expect(merged.mergedAt).not.toBeNull();
+  });
+
+  it("returns 405 when the request method is not POST", async () => {
+    await createBranch(getTestDb(), project.id);
+
+    const response = await callAction({ method: "GET" });
+
+    expect(response.status).toBe(405);
+    const body = await response.json();
+    expect(body.error).toBe("Method not allowed");
+  });
+
+  it("returns 404 when the project does not exist", async () => {
+    const response = await callAction({ projectSlug: "missing" });
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe('Project "missing" not found');
+  });
+
+  it("returns 404 when the branch does not exist", async () => {
+    const response = await callAction({ branchSlug: "missing-branch" });
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe('Branch "missing-branch" not found');
+  });
+
+  it("returns 400 when the branch is already merged", async () => {
+    const branch = await createBranch(getTestDb(), project.id, {
+      status: BRANCH_STATUS.MERGED,
+    });
+    expect(branch.status).toBe(BRANCH_STATUS.MERGED);
+
+    const response = await callAction();
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe(
+      'Branch "feature-branch" is already merged or closed',
+    );
+  });
+});

--- a/apps/website/app/routes/api.orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.tsx
+++ b/apps/website/app/routes/api.orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.tsx
@@ -1,0 +1,72 @@
+import { getProjectBySlug } from "~/lib/projects.server";
+import { getBranchBySlug, mergeBranch } from "~/lib/branches.server";
+import { orgContext } from "~/middleware/api-auth.server";
+import { getInstance } from "~/middleware/i18next.server";
+import { apiError } from "~/lib/api-response.server";
+import type { Route } from "./+types/api.orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge";
+
+export async function action({ request, params, context }: Route.ActionArgs) {
+  const i18next = getInstance(context);
+
+  if (request.method !== "POST") {
+    return apiError(405, i18next.t("api.methodNotAllowed"));
+  }
+
+  const organization = context.get(orgContext);
+
+  const project = await getProjectBySlug(organization.id, params.projectSlug);
+  if (!project) {
+    return apiError(
+      404,
+      i18next.t("api.translate.projectNotFound", {
+        projectSlug: params.projectSlug,
+      }),
+    );
+  }
+
+  const branch = await getBranchBySlug(project.id, params.branchSlug);
+  if (!branch) {
+    return apiError(
+      404,
+      i18next.t("api.branchMerge.branchNotFound", {
+        branchSlug: params.branchSlug,
+      }),
+    );
+  }
+
+  // API merges are not attributed to a specific user — `mergedBy` is always null.
+  const result = await mergeBranch(branch.id, null);
+
+  if (result.success) {
+    return Response.json({
+      success: true as const,
+      keysMoved: result.keysMoved,
+      keysDeleted: result.keysDeleted,
+    });
+  }
+
+  switch (result.reason) {
+    case "not_found":
+      return apiError(
+        404,
+        i18next.t("api.branchMerge.branchNotFound", {
+          branchSlug: params.branchSlug,
+        }),
+      );
+    case "not_open":
+      return apiError(
+        400,
+        i18next.t("api.branchMerge.branchNotOpen", {
+          branchSlug: params.branchSlug,
+        }),
+      );
+    case "conflict":
+      return Response.json(
+        {
+          error: result.error,
+          conflictingKeys: result.conflictingKeys ?? [],
+        },
+        { status: 409 },
+      );
+  }
+}

--- a/apps/website/app/routes/api.orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.tsx
+++ b/apps/website/app/routes/api.orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.tsx
@@ -1,5 +1,6 @@
 import { getProjectBySlug } from "~/lib/projects.server";
 import { getBranchBySlug, mergeBranch } from "~/lib/branches.server";
+import { MERGE_FAILURE_REASON } from "~/lib/branches";
 import { orgContext } from "~/middleware/api-auth.server";
 import { getInstance } from "~/middleware/i18next.server";
 import { apiError } from "~/lib/api-response.server";
@@ -46,21 +47,21 @@ export async function action({ request, params, context }: Route.ActionArgs) {
   }
 
   switch (result.reason) {
-    case "not_found":
+    case MERGE_FAILURE_REASON.NOT_FOUND:
       return apiError(
         404,
         i18next.t("api.branchMerge.branchNotFound", {
           branchSlug: params.branchSlug,
         }),
       );
-    case "not_open":
+    case MERGE_FAILURE_REASON.NOT_OPEN:
       return apiError(
         400,
         i18next.t("api.branchMerge.branchNotOpen", {
           branchSlug: params.branchSlug,
         }),
       );
-    case "conflict":
+    case MERGE_FAILURE_REASON.CONFLICT:
       return Response.json(
         {
           error: result.error,

--- a/apps/website/app/routes/api.orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.tsx
+++ b/apps/website/app/routes/api.orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.tsx
@@ -61,13 +61,5 @@ export async function action({ request, params, context }: Route.ActionArgs) {
           branchSlug: params.branchSlug,
         }),
       );
-    case MERGE_FAILURE_REASON.CONFLICT:
-      return Response.json(
-        {
-          error: result.error,
-          conflictingKeys: result.conflictingKeys ?? [],
-        },
-        { status: 409 },
-      );
   }
 }

--- a/apps/website/app/routes/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.tsx
+++ b/apps/website/app/routes/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.tsx
@@ -9,7 +9,6 @@ import {
   Badge,
   Card,
   Code,
-  List,
 } from "@chakra-ui/react";
 import {
   Link,
@@ -69,7 +68,7 @@ export async function action({ params, context }: Route.ActionArgs) {
   const result = await mergeBranch(branch.id, user.userId);
 
   if (!result.success) {
-    return { error: result.error, conflictingKeys: result.conflictingKeys };
+    return { error: result.error };
   }
 
   return redirect(getBranchesUrl(params.orgSlug, params.projectSlug));
@@ -115,13 +114,6 @@ export default function MergeBranch({ loaderData }: Route.ComponentProps) {
               {actionData?.error && (
                 <Box p={4} bg="red.subtle" color="red.fg" borderRadius="md">
                   <Text fontWeight="semibold">{actionData.error}</Text>
-                  {actionData.conflictingKeys && (
-                    <List.Root mt={2}>
-                      {actionData.conflictingKeys.map((key: string) => (
-                        <List.Item key={key}>{key}</List.Item>
-                      ))}
-                    </List.Root>
-                  )}
                 </Box>
               )}
 

--- a/docs/technical-notes/README.md
+++ b/docs/technical-notes/README.md
@@ -13,6 +13,7 @@ Detailed technical documentation for the transi-store implementation.
 | [database-schema.md](./database-schema.md)             | Full PostgreSQL schema, constraints, relations, TypeScript types    |
 | [export-api.md](./export-api.md)                       | JSON/XLIFF export API, authentication by key or session             |
 | [import-system.md](./import-system.md)                 | Bulk import, overwrite/skip strategies, validation                  |
+| [branch-merge-api.md](./branch-merge-api.md)           | Branch merge API + CLI, shared `mergeBranch` logic, status codes    |
 | [code-patterns.md](./code-patterns.md)                 | Common patterns (routes, Drizzle queries, forms, auth)              |
 | [code-formatting.md](./code-formatting.md)             | Prettier formatting rules                                           |
 | [traductions.md](./traductions.md)                     | Website translation management (i18next)                            |

--- a/docs/technical-notes/branch-merge-api.md
+++ b/docs/technical-notes/branch-merge-api.md
@@ -1,0 +1,42 @@
+# Branch merge API
+
+## Endpoint
+
+`POST /api/orgs/:orgSlug/projects/:projectSlug/branches/:branchSlug/merge`
+
+Merges an open branch into main. The business logic lives in `mergeBranch()` (`apps/website/app/lib/branches.server.ts`) and is shared with the UI route at `routes/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.merge.tsx`.
+
+## Authentication
+
+The route sits under the `api/orgs/:orgSlug` layout, so it goes through the standard `apiAuthMiddleware` + `apiOrgMiddleware` pipeline (`apps/website/app/middleware/api-auth.server.ts`). Both authentication modes accepted by other API endpoints work here:
+
+- Bearer API key (`Authorization: Bearer <key>`)
+- Session cookie
+
+The route **does not** look up the calling user. `mergeBranch()` is called with `mergedBy = null` regardless of the auth mode. This is intentional: the API entry point is primarily used by automation (CI/CD via `@transi-store/cli`), and we don't want to surface a partial actor identity (API key id vs. user id) on the merge record. Only the UI action attributes the merge to a specific user.
+
+## Status codes
+
+| Code | Body schema | When |
+|------|-------------|------|
+| `200` | `BranchMergeSuccess` (`{ success: true, keysMoved, keysDeleted }`) | Merge succeeded. |
+| `400` | `BranchMergeError` (`{ error }`) | Branch exists but is not open (already merged or closed). |
+| `401` | `BranchMergeError` | Missing or invalid API key, no session. |
+| `403` | `BranchMergeError` | API key does not belong to the requested organization. |
+| `404` | `BranchMergeError` | Project or branch not found. |
+| `405` | `BranchMergeError` | Request method is not `POST`. |
+| `409` | `BranchMergeConflict` (`{ error, conflictingKeys[] }`) | Some branch keys collide with existing main keys. |
+
+`409` is reserved strictly for the unique-constraint conflict case, so clients can rely on the presence of `conflictingKeys` whenever they receive that status.
+
+## Discriminated result in `mergeBranch`
+
+`MergeBranchResult` carries a `reason` field on failure (`"not_found" | "not_open" | "conflict"`). The API route maps `reason` to a status code without string-matching on `error`. The UI keeps reading `error` and `conflictingKeys` as before.
+
+## CLI
+
+The `transi-store branch:merge` command (in `@transi-store/cli`) wraps this endpoint. `--branch` is required: there is no git auto-detection, since the merge is destructive and the target must be explicit. On `409` the CLI prints every conflicting key on its own line and exits `1`.
+
+## OpenAPI
+
+Schemas live in `apps/website/app/lib/api-doc/schemas/branch-merge.ts` and are registered in `apps/website/app/lib/api-doc/openapi.server.ts` alongside the existing translation endpoints.

--- a/packages/cli/src/branchMerge.ts
+++ b/packages/cli/src/branchMerge.ts
@@ -23,7 +23,6 @@ export async function mergeBranchCommand({
       method: "POST",
       headers: {
         Authorization: `Bearer ${apiKey}`,
-        "Content-Length": "0",
       },
     });
   } catch (error) {

--- a/packages/cli/src/branchMerge.ts
+++ b/packages/cli/src/branchMerge.ts
@@ -32,27 +32,23 @@ export async function mergeBranchCommand({
     process.exit(1);
   }
 
-  const body = await response.text();
-  let data: unknown = null;
-  if (body.length > 0) {
-    try {
-      data = JSON.parse(body);
-    } catch {
-      // Non-JSON body — keep raw text for diagnostics
-    }
+  let data:
+    | { keysMoved?: number; keysDeleted?: number; error?: string }
+    | null = null;
+  try {
+    data = await response.json();
+  } catch {
+    // Empty or non-JSON body — fall back to statusText below.
   }
 
   if (response.ok) {
-    const stats = data as { keysMoved?: number; keysDeleted?: number } | null;
     console.log(
-      `Branch "${branch}" merged on project "${project}": ${stats?.keysMoved ?? 0} keys moved, ${stats?.keysDeleted ?? 0} deleted.`,
+      `Branch "${branch}" merged on project "${project}": ${data?.keysMoved ?? 0} keys moved, ${data?.keysDeleted ?? 0} deleted.`,
     );
     return;
   }
 
-  const errorFromData = (data as { error?: string } | null)?.error;
-  const errorMessage =
-    errorFromData ?? (body.trim() || response.statusText);
+  const errorMessage = data?.error ?? response.statusText;
   console.error(
     `Failed to merge branch (${response.status} ${response.statusText}): ${errorMessage}`,
   );

--- a/packages/cli/src/branchMerge.ts
+++ b/packages/cli/src/branchMerge.ts
@@ -1,6 +1,6 @@
 import { describeFetchError } from "./fetchProjectMetadata.ts";
 
-export type MergeBranchOptions = {
+type MergeBranchOptions = {
   domainRoot: string;
   apiKey: string;
   org: string;

--- a/packages/cli/src/branchMerge.ts
+++ b/packages/cli/src/branchMerge.ts
@@ -15,7 +15,7 @@ export async function mergeBranchCommand({
   project,
   branch,
 }: MergeBranchOptions): Promise<void> {
-  const url = `${domainRoot}/api/orgs/${org}/projects/${project}/branches/${branch}/merge`;
+  const url = `${domainRoot}/api/orgs/${encodeURIComponent(org)}/projects/${encodeURIComponent(project)}/branches/${encodeURIComponent(branch)}/merge`;
 
   let response: Response;
   try {
@@ -49,20 +49,6 @@ export async function mergeBranchCommand({
       `Branch "${branch}" merged on project "${project}": ${stats?.keysMoved ?? 0} keys moved, ${stats?.keysDeleted ?? 0} deleted.`,
     );
     return;
-  }
-
-  if (response.status === 409) {
-    const conflict = data as {
-      error?: string;
-      conflictingKeys?: string[];
-    } | null;
-    console.error(
-      `Merge conflict: ${conflict?.error ?? "Conflicting keys exist on main"}`,
-    );
-    for (const key of conflict?.conflictingKeys ?? []) {
-      console.error(`  - ${key}`);
-    }
-    process.exit(1);
   }
 
   const errorFromData = (data as { error?: string } | null)?.error;

--- a/packages/cli/src/branchMerge.ts
+++ b/packages/cli/src/branchMerge.ts
@@ -1,0 +1,75 @@
+import { describeFetchError } from "./fetchProjectMetadata.ts";
+
+export type MergeBranchOptions = {
+  domainRoot: string;
+  apiKey: string;
+  org: string;
+  project: string;
+  branch: string;
+};
+
+export async function mergeBranchCommand({
+  domainRoot,
+  apiKey,
+  org,
+  project,
+  branch,
+}: MergeBranchOptions): Promise<void> {
+  const url = `${domainRoot}/api/orgs/${org}/projects/${project}/branches/${branch}/merge`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Length": "0",
+      },
+    });
+  } catch (error) {
+    console.error(
+      `Failed to merge branch at ${url}: ${describeFetchError(error)}`,
+    );
+    process.exit(1);
+  }
+
+  const body = await response.text();
+  let data: unknown = null;
+  if (body.length > 0) {
+    try {
+      data = JSON.parse(body);
+    } catch {
+      // Non-JSON body — keep raw text for diagnostics
+    }
+  }
+
+  if (response.ok) {
+    const stats = data as { keysMoved?: number; keysDeleted?: number } | null;
+    console.log(
+      `Branch "${branch}" merged on project "${project}": ${stats?.keysMoved ?? 0} keys moved, ${stats?.keysDeleted ?? 0} deleted.`,
+    );
+    return;
+  }
+
+  if (response.status === 409) {
+    const conflict = data as {
+      error?: string;
+      conflictingKeys?: string[];
+    } | null;
+    console.error(
+      `Merge conflict: ${conflict?.error ?? "Conflicting keys exist on main"}`,
+    );
+    for (const key of conflict?.conflictingKeys ?? []) {
+      console.error(`  - ${key}`);
+    }
+    process.exit(1);
+  }
+
+  const errorFromData = (data as { error?: string } | null)?.error;
+  const errorMessage =
+    errorFromData ?? (body.trim() || response.statusText);
+  console.error(
+    `Failed to merge branch (${response.status} ${response.statusText}): ${errorMessage}`,
+  );
+  process.exit(1);
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,6 +10,7 @@ import {
   uploadOne,
   type UploadOneOptions,
 } from "./uploadTranslations.ts";
+import { mergeBranchCommand } from "./branchMerge.ts";
 import {
   DEFAULT_DOMAIN_ROOT,
   ALL_BRANCHES_VALUE,
@@ -146,6 +147,28 @@ program
       validateStrategy(options.strategy),
       options.branch,
     );
+  });
+
+program
+  .command("branch:merge")
+  .description("Merge a project branch into main")
+  .addOption(apiKeyOption)
+  .requiredOption(
+    "-d, --domain-root <domainRoot>",
+    "Root domain of the Transi-Store instance (default is https://transi-store.com)",
+    DEFAULT_DOMAIN_ROOT,
+  )
+  .requiredOption("-o, --org <org>", "Organization slug")
+  .requiredOption("-p, --project <project>", "Project slug")
+  .requiredOption("-b, --branch <branch>", "Branch slug to merge")
+  .action((options) => {
+    mergeBranchCommand({
+      domainRoot: options.domainRoot,
+      apiKey: options.apiKey,
+      org: options.org,
+      project: options.project,
+      branch: options.branch,
+    });
   });
 
 program.parse();


### PR DESCRIPTION
Add POST /api/orgs/:orgSlug/projects/:projectSlug/branches/:branchSlug/merge
and the matching `transi-store branch:merge` CLI command, both reusing the
existing `mergeBranch` logic shared with the UI action. The shared helper now
accepts a nullable `mergedBy`: API merges are never attributed to a specific
user (the column is already nullable in the schema, so no migration is
required). The result type carries a `reason` discriminant so the route maps
to distinct status codes (404 / 400 / 409) without string-matching.

https://claude.ai/code/session_01KAB5QWbASYNet44xF1Pr33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Commande CLI branch:merge pour fusionner une branche vers main (option --branch requise).
  * Endpoint HTTP POST pour déclencher une fusion et recevoir un résumé (keysMoved / keysDeleted).

* **Documentation**
  * Guides et schémas mis à jour (FR/EN/DE/ES) avec exemples curl, encodage d’URL et usages CLI/API.

* **Tests & Localisation**
  * Tests d’endpoint ajoutés et nouvelles chaînes de traduction pour erreurs de merge.

* **Comportement**
  * En cas de conflit, la CLI affiche les clés conflictuelles et quitte avec code 1; l’interface web n’affiche plus la liste des clés conflictuelles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/transi-store/transi-store/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->