### PR TITLE
fix file list overflow

### DIFF
--- a/apps/website/app/components/project-files/ProjectFileTabs.tsx
+++ b/apps/website/app/components/project-files/ProjectFileTabs.tsx
@@ -1,9 +1,20 @@
-import { HStack, Tabs, Badge, Code, IconButton } from "@chakra-ui/react";
+import {
+  HStack,
+  Tabs,
+  Badge,
+  Code,
+  IconButton,
+  Box,
+  Button,
+  Menu,
+  Portal,
+} from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
-import { LuPlus, LuPencil } from "react-icons/lu";
+import { LuPlus, LuPencil, LuChevronDown, LuCheck } from "react-icons/lu";
 import { FORMAT_LABELS, SupportedFormat } from "@transi-store/common";
 import type { ProjectFile } from "../../../drizzle/schema";
 import { ProjectAccessRole } from "~/lib/project-visibility";
+import { useOverflowDetection } from "./useOverflowDetection";
 
 type ProjectFileTabsProps = {
   files: Array<ProjectFile>;
@@ -13,6 +24,10 @@ type ProjectFileTabsProps = {
   onEditFile: (file: ProjectFile) => void;
   onAddFile: () => void;
 };
+
+function formatLabel(file: ProjectFile): string {
+  return FORMAT_LABELS[file.format as SupportedFormat] ?? file.format;
+}
 
 export function ProjectFileTabs({
   files,
@@ -25,44 +40,141 @@ export function ProjectFileTabs({
   const { t } = useTranslation();
   const canEdit = projectAccessRole === ProjectAccessRole.MEMBER;
 
+  // The tab strip is always rendered (hidden when overflowing) so its natural
+  // width can keep being measured against the available slot width, even after
+  // we switch to the menu. This keeps the detection reactive to resizes.
+  const {
+    containerRef: slotRef,
+    contentRef: stripRef,
+    isOverflowing,
+  } = useOverflowDetection(files);
+
+  const selectedFile =
+    selectedFileId !== null
+      ? (files.find((file) => file.id === selectedFileId) ?? null)
+      : null;
+
   return (
     <Tabs.Root
       value={selectedFileId !== null ? String(selectedFileId) : undefined}
       variant="line"
       size="sm"
     >
-      <HStack align="center" gap={2} wrap="wrap">
-        <Tabs.List flex="1" minW={0}>
-          {files.map((file) => (
-            <HStack key={file.id} gap={0} align="center">
-              <Tabs.Trigger
-                value={String(file.id)}
-                cursor="pointer"
-                onClick={() => onFileClick(file)}
-              >
-                <Code fontSize="xs">{file.filePath}</Code>
-                <Badge size="xs" ml={2}>
-                  {FORMAT_LABELS[file.format as SupportedFormat] ?? file.format}
-                </Badge>
-              </Tabs.Trigger>
-              {canEdit && (
-                <IconButton
-                  aria-label={t("files.editFile")}
-                  size="xs"
-                  variant="ghost"
-                  onClick={() => onEditFile(file)}
+      <HStack align="center" gap={2} wrap="nowrap">
+        <Box
+          ref={slotRef}
+          flex="1"
+          minW={0}
+          position="relative"
+          overflow="hidden"
+          borderBottomWidth={isOverflowing ? "1px" : undefined}
+          borderColor="border"
+        >
+          <Tabs.List
+            ref={stripRef}
+            flexWrap="nowrap"
+            w={isOverflowing ? "max-content" : "100%"}
+            position={isOverflowing ? "absolute" : "static"}
+            visibility={isOverflowing ? "hidden" : "visible"}
+            pointerEvents={isOverflowing ? "none" : undefined}
+            aria-hidden={isOverflowing}
+          >
+            {files.map((file) => (
+              <HStack key={file.id} gap={0} align="center" flexShrink={0}>
+                <Tabs.Trigger
+                  value={String(file.id)}
+                  cursor="pointer"
+                  onClick={() => onFileClick(file)}
                 >
-                  <LuPencil />
-                </IconButton>
-              )}
-            </HStack>
-          ))}
-        </Tabs.List>
+                  <Code fontSize="xs">{file.filePath}</Code>
+                  <Badge size="xs" ml={2}>
+                    {formatLabel(file)}
+                  </Badge>
+                </Tabs.Trigger>
+                {canEdit && (
+                  <IconButton
+                    aria-label={t("files.editFile")}
+                    size="xs"
+                    variant="ghost"
+                    onClick={() => onEditFile(file)}
+                  >
+                    <LuPencil />
+                  </IconButton>
+                )}
+              </HStack>
+            ))}
+          </Tabs.List>
+
+          {isOverflowing && (
+            <Menu.Root>
+              <Menu.Trigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  maxW="full"
+                  borderRadius="0"
+                  borderBottomWidth="2px"
+                  borderBottomColor={
+                    selectedFile ? "colorPalette.solid" : "transparent"
+                  }
+                >
+                  {selectedFile ? (
+                    <>
+                      <Code fontSize="xs">{selectedFile.filePath}</Code>
+                      <Badge size="xs" ml={2}>
+                        {formatLabel(selectedFile)}
+                      </Badge>
+                    </>
+                  ) : (
+                    t("files.selectFile")
+                  )}
+                  <LuChevronDown />
+                </Button>
+              </Menu.Trigger>
+              <Portal>
+                <Menu.Positioner>
+                  <Menu.Content maxH="20rem" minW="14rem">
+                    {files.map((file) => (
+                      <Menu.Item
+                        key={file.id}
+                        value={String(file.id)}
+                        onClick={() => onFileClick(file)}
+                      >
+                        <Box w={4} flexShrink={0}>
+                          {file.id === selectedFileId && <LuCheck />}
+                        </Box>
+                        <Code fontSize="xs">{file.filePath}</Code>
+                        <Badge size="xs" ml={2}>
+                          {formatLabel(file)}
+                        </Badge>
+                        <Box flex="1" />
+                        {canEdit && (
+                          <IconButton
+                            aria-label={t("files.editFile")}
+                            size="xs"
+                            variant="ghost"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              onEditFile(file);
+                            }}
+                          >
+                            <LuPencil />
+                          </IconButton>
+                        )}
+                      </Menu.Item>
+                    ))}
+                  </Menu.Content>
+                </Menu.Positioner>
+              </Portal>
+            </Menu.Root>
+          )}
+        </Box>
         {canEdit && (
           <IconButton
             aria-label={t("files.addFile")}
             size="xs"
             variant="ghost"
+            flexShrink={0}
             onClick={onAddFile}
           >
             <LuPlus />

--- a/apps/website/app/components/project-files/useOverflowDetection.ts
+++ b/apps/website/app/components/project-files/useOverflowDetection.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+
+type OverflowDetection = {
+  /** Attach to the element that defines the available width. */
+  containerRef: RefObject<HTMLDivElement | null>;
+  /** Attach to the element holding the items at their natural width. */
+  contentRef: RefObject<HTMLDivElement | null>;
+  isOverflowing: boolean;
+};
+
+/**
+ * Detects whether a horizontally laid-out strip of items overflows the width
+ * available in its container.
+ *
+ * The `contentRef` element is expected to keep being rendered (even when
+ * hidden) while overflowing, so its natural width can keep being measured and
+ * the detection stays reactive to container resizes.
+ *
+ * Pass `dependency` (e.g. the list being rendered) so the measurement re-runs
+ * when the content changes.
+ */
+export function useOverflowDetection(dependency: unknown): OverflowDetection {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const content = contentRef.current;
+    if (!container || !content) {
+      return;
+    }
+
+    const check = () => {
+      setIsOverflowing(content.scrollWidth > container.clientWidth + 1);
+    };
+
+    check();
+    const observer = new ResizeObserver(check);
+    observer.observe(container);
+    observer.observe(content);
+
+    return () => observer.disconnect();
+  }, [dependency]);
+
+  return { containerRef, contentRef, isOverflowing };
+}

--- a/apps/website/app/locales/de/translation.json
+++ b/apps/website/app/locales/de/translation.json
@@ -84,6 +84,7 @@
   "export.title": "Übersetzungen exportieren",
   "files.addFile": "Datei hinzufügen",
   "files.editFile": "Datei bearbeiten",
+  "files.selectFile": "Datei auswählen",
   "files.errors.duplicatePath": "Eine Datei mit dem Pfad „{filePath}“ existiert bereits",
   "files.errors.fileNotFound": "Datei „{fileId}“ im Projekt „{projectSlug}“ nicht gefunden",
   "files.errors.invalidFileId": "Ungültige Datei-ID „{fileId}“",

--- a/apps/website/app/locales/en/translation.json
+++ b/apps/website/app/locales/en/translation.json
@@ -84,6 +84,7 @@
   "export.title": "Export translations",
   "files.addFile": "Add file",
   "files.editFile": "Edit file",
+  "files.selectFile": "Select a file",
   "files.errors.duplicatePath": "A file with path \"{filePath}\" already exists",
   "files.errors.fileNotFound": "File \"{fileId}\" not found in project \"{projectSlug}\"",
   "files.errors.invalidFileId": "Invalid file ID \"{fileId}\"",

--- a/apps/website/app/locales/es/translation.json
+++ b/apps/website/app/locales/es/translation.json
@@ -66,6 +66,7 @@
   "export.title": "Exportar traducciones",
   "files.addFile": "Añadir archivo",
   "files.editFile": "Editar archivo",
+  "files.selectFile": "Seleccionar un archivo",
   "files.errors.duplicatePath": "Ya existe un archivo con la ruta «{filePath}»",
   "files.errors.fileNotFound": "Archivo «{fileId}» no encontrado en el proyecto «{projectSlug}»",
   "files.errors.invalidFileId": "ID de archivo inválido «{fileId}»",

--- a/apps/website/app/locales/fr/translation.json
+++ b/apps/website/app/locales/fr/translation.json
@@ -84,6 +84,7 @@
   "export.title": "Exporter des traductions",
   "files.addFile": "Ajouter un fichier",
   "files.editFile": "Éditer le fichier",
+  "files.selectFile": "Sélectionner un fichier",
   "files.errors.duplicatePath": "Un fichier avec le chemin « {filePath} » existe déjà",
   "files.errors.fileNotFound": "Fichier « {fileId} » introuvable dans le projet « {projectSlug} »",
   "files.errors.invalidFileId": "Identifiant de fichier invalide « {fileId} »",


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Prevent project file tab strip overflow with dropdown fallback
<code>🐞 Bug fix</code> <code>⚙️ Configuration changes</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Detect when the file tab strip overflows and switch to a compact dropdown selector.
• Keep edit/add actions accessible when overflow occurs (including per-file edit in menu).
• Add i18n copy for the new &quot;Select a file&quot; placeholder.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Translations route"] --> B["ProjectFileTabs"] --> C("useOverflowDetection") --> D["ResizeObserver"]
  B --> E["Tabs.List strip"]
  B --> F["Menu dropdown"]
  B --> G[("i18n translations")]

  subgraph Legend
    direction LR
    _cmp["Component"] ~~~ _hook("Hook") ~~~ _cfg[("Config/Strings")]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Allow horizontal scrolling tabs</b></summary>

- ➕ Simpler UI (no mode switch)
- ➕ Less custom logic (could be mostly CSS: overflow-x:auto)
- ➖ Discoverability may be worse (hidden tabs)
- ➖ Still awkward to select far-right items on touch/trackpads
- ➖ Doesn&#x27;t solve very long paths well

</details>

<details>
<summary><b>2. Use existing responsive Tabs/Menu component (if available)</b></summary>

- ➕ Less bespoke overflow measurement code
- ➕ Potentially better accessibility and keyboard behavior out of the box
- ➖ May not exist in current Chakra setup
- ➖ Could constrain custom layout (badges, per-item edit actions)

</details>

**Recommendation:** Current approach (overflow detection + dropdown fallback) is appropriate because it preserves a clean tab UX when space allows while guaranteeing full access to all files when it doesn&#x27;t. The dedicated hook keeps the measuring logic reusable and localized, and keeping the tab strip rendered-but-hidden maintains responsive behavior on resize.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>useOverflowDetection.ts</strong> <code>Add ResizeObserver-based hook to detect horizontal overflow</code> <code>+47/-0</code></summary>

<br/>

>Add ResizeObserver-based hook to detect horizontal overflow
>
><pre>
>• Introduces a reusable hook that compares content scrollWidth to container clientWidth and updates on resize via ResizeObserver. Accepts a dependency to re-run measurement when the rendered content changes.
></pre>
>
><a href='https://github.com/transi-store/transi-store/pull/215/files#diff-421cbe326a2f19457211ae795ad8b714b8ce049219bd67e1a04c8b526e9d1a2e'>apps/website/app/components/project-files/useOverflowDetection.ts</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>ProjectFileTabs.tsx</strong> <code>Switch file navigation from wrapping tabs to overflow-aware dropdown</code> <code>+139/-27</code></summary>

<br/>

>Switch file navigation from wrapping tabs to overflow-aware dropdown
>
><pre>
>• Reworks the file tabs layout to avoid wrapping/overflow by measuring available width and conditionally rendering a dropdown selector. Keeps the tab strip rendered (hidden) for accurate measurement, adds a selected-file placeholder, and supports per-file edit actions inside the menu with event propagation handling.
></pre>
>
><a href='https://github.com/transi-store/transi-store/pull/215/files#diff-34f1431d3b060925a5d9493b646cd18942ace0ef23335cb5d0b9ba557a00c35d'>apps/website/app/components/project-files/ProjectFileTabs.tsx</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (4)</summary>

<blockquote>
<details>
<summary><strong>translation.json</strong> <code>Add German string for file selection placeholder</code> <code>+1/-0</code></summary>

<br/>

>Add German string for file selection placeholder
>
><pre>
>• Adds the new &quot;files.selectFile&quot; translation used when no file is selected in overflow mode.
></pre>
>
><a href='https://github.com/transi-store/transi-store/pull/215/files#diff-4df3316cdc160fc85ca7886627515739389c763d94d3eeeff6a3e88b5fa7fd26'>apps/website/app/locales/de/translation.json</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>translation.json</strong> <code>Add English string for file selection placeholder</code> <code>+1/-0</code></summary>

<br/>

>Add English string for file selection placeholder
>
><pre>
>• Adds the new &quot;files.selectFile&quot; translation used when no file is selected in overflow mode.
></pre>
>
><a href='https://github.com/transi-store/transi-store/pull/215/files#diff-194ee8f9bd5dc229d4ae750e02f0ef79920c69cf29e980500232532f9de52682'>apps/website/app/locales/en/translation.json</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>translation.json</strong> <code>Add Spanish string for file selection placeholder</code> <code>+1/-0</code></summary>

<br/>

>Add Spanish string for file selection placeholder
>
><pre>
>• Adds the new &quot;files.selectFile&quot; translation used when no file is selected in overflow mode.
></pre>
>
><a href='https://github.com/transi-store/transi-store/pull/215/files#diff-5392abc622216d934744067d9c83bf019671230b01a5809f0930ef44a7c5e909'>apps/website/app/locales/es/translation.json</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>translation.json</strong> <code>Add French string for file selection placeholder</code> <code>+1/-0</code></summary>

<br/>

>Add French string for file selection placeholder
>
><pre>
>• Adds the new &quot;files.selectFile&quot; translation used when no file is selected in overflow mode.
></pre>
>
><a href='https://github.com/transi-store/transi-store/pull/215/files#diff-26f8e265b0fa724ad7898db5746c3336d33e95e34557f302e4126ee2b1328709'>apps/website/app/locales/fr/translation.json</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Nouvelles Fonctionnalités**
  * Gestion intelligente du débordement des onglets : un menu déroulant remplace automatiquement les onglets lorsque l'espace disponible est insuffisant.

* **Localisations**
  * Ajout de traductions pour la sélection de fichiers en allemand, anglais, espagnol et français.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->