### PR TITLE
Fix deletion search

### DIFF
--- a/apps/website/app/routes/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.tsx
+++ b/apps/website/app/routes/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.tsx
@@ -725,9 +725,24 @@ function BranchKeysDetail({ loaderData }: { loaderData: KeysLoaderData }) {
                     {t("branches.deletions.searchMainKeys")}
                   </Text>
                   <Form method="get">
-                    {/* Preserve existing search params */}
+                    {/* Preserve the params the loader needs: without fileId it
+                        redirects and drops deletionSearch, so the search would
+                        always return nothing. Keep sort/filter/locale too so the
+                        additions tab state survives a deletion search. */}
                     {search && (
                       <input type="hidden" name="search" value={search} />
+                    )}
+                    {selectedFileId !== null && (
+                      <input
+                        type="hidden"
+                        name="fileId"
+                        value={String(selectedFileId)}
+                      />
+                    )}
+                    <input type="hidden" name="sort" value={sort} />
+                    <input type="hidden" name="filter" value={filter} />
+                    {locale && (
+                      <input type="hidden" name="locale" value={locale} />
                     )}
                     <HStack>
                       <Input


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Preserve fileId and tab state when searching deletions
<code>🐞 Bug fix</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Preserve required query params when submitting deletion search.
• Prevent loader redirect from dropping deletionSearch and returning empty results.
• Keep sort/filter/locale so additions tab state survives deletion searches.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  U["User"] --> F["Deletions search form"] --> Q["GET query params\n(fileId + deletionSearch + sort/filter/locale)"] --> R["Branch route\norgs/.../branches/..." ] --> L["loader()"] --> S["searchMainKeysForDeletion()"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Preserve deletionSearch in the loader redirect</b></summary>

- ➕ Fixes the root cause regardless of which UI submits the request
- ➕ Protects against other callers missing fileId
- ➖ Still incurs a redirect round-trip when fileId is absent
- ➖ Requires carefully forwarding all relevant params to avoid similar regressions

</details>

<details>
<summary><b>2. Build the GET action URL by merging existing URLSearchParams</b></summary>

- ➕ Automatically preserves all current params without manually listing them
- ➕ Reduces risk of missing a new param in the future
- ➖ More code/indirection in the component
- ➖ Can accidentally preserve unrelated params if not filtered

</details>

**Recommendation:** Current approach is good for UX: including fileId (and sort/filter/locale) in the deletions search GET request avoids the loader redirect entirely and keeps UI state stable. If similar issues recur, also consider hardening the loader redirect to forward deletionSearch defensively.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.tsx</strong> <code>Preserve required query params in deletions search GET form</code> <code>+16/-1</code></summary>

<br/>

>Preserve required query params in deletions search GET form
>
><pre>
>• Updates the deletions search form to include hidden inputs for fileId, sort, filter, and locale (in addition to existing search). This prevents the loader from redirecting due to a missing fileId and dropping deletionSearch, which previously caused deletion searches to always return empty results.
></pre>
>
><a href='https://github.com/transi-store/transi-store/pull/216/files#diff-032bdd784c77daf6ba08385983701680287d8f8212e81d6b3dd32b5acc3ec913'>apps/website/app/routes/orgs.$orgSlug.projects.$projectSlug.branches.$branchSlug.tsx</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>